### PR TITLE
fix: harden cross-platform library query contracts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ _Avoid_: offset, page number
 - A **Track** has **Library Metadata** and may have **Embedded Metadata**
 - **Track Metadata** may combine **Library Metadata** and **Embedded Metadata**
 - A **Track** or **Album** may have zero or one **Artwork Reference**
-- A **Cursor** points to one **Track**, **Album**, or **Artist** in a paginated list
+- A **Cursor** points to one **Track**, **Album**, or **Artist** in a paginated list and is valid only with the entity type, filters, and sort that produced it
 
 ## Example dialogue
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,11 @@ async function fetchAllTracks() {
 }
 ```
 
+For workflows that need the complete current result, use
+`getAllTracksAsync`, `getAllTracksByArtistAsync`, `getAllAlbumsAsync`, or
+`getAllArtistsAsync`. These helpers follow `endCursor`, preserve the low-level
+query options, and reject malformed or non-advancing native pagination.
+
 ## 🤝 Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ getTracksAsync(options?: TrackOptions): Promise<PaginatedResult<Track>>
 
 **TrackOptions**
 
-| Property    | Type                                                     | Default     | Description                             |
-| ----------- | -------------------------------------------------------- | ----------- | --------------------------------------- |
-| `first`     | `number`                                                 | `20`        | Items to return (`1`–`1000`)            |
-| `after`     | `string`                                                 | —           | Cursor from previous page's `endCursor` |
-| `sortBy`    | `TrackSortByKey \| [TrackSortByKey, boolean] \| (...)[]` | `'default'` | Sort key, or tuple `[key, ascending]`   |
-| `directory` | `string`                                                 | —           | Filter by directory path (Android only) |
+| Property    | Type                                                     | Default     | Description                                          |
+| ----------- | -------------------------------------------------------- | ----------- | ---------------------------------------------------- |
+| `first`     | `number`                                                 | `20`        | Items to return (`1`–`1000`)                         |
+| `after`     | `string`                                                 | —           | Cursor from previous page's `endCursor`              |
+| `sortBy`    | `TrackSortByKey \| [TrackSortByKey, boolean] \| (...)[]` | `'default'` | Sort key, or tuple `[key, ascending]`                |
+| `directory` | `string`                                                 | —           | Legacy path or supported SAF tree URI (Android only) |
 
 **TrackSortByKey**: `'default' \| 'title' \| 'artist' \| 'album' \| 'duration' \| 'createdAt' \| 'modifiedAt' \| 'fileSize'`
 
@@ -191,18 +191,34 @@ getArtistsAsync(options?: ArtistOptions): Promise<PaginatedResult<Artist>>
 
 ### `Track`
 
-| Field        | Type      | Description                                               |
-| ------------ | --------- | --------------------------------------------------------- |
-| `id`         | `string`  | Unique identifier                                         |
-| `title`      | `string`  | Track title                                               |
-| `artist`     | `string`  | Artist name                                               |
-| `artwork`    | `string?` | Artwork file URI (may be undefined)                       |
-| `album`      | `string`  | Album name                                                |
-| `duration`   | `number`  | Duration in seconds                                       |
-| `url`        | `string`  | File URI                                                  |
-| `createdAt`  | `number?` | Date added, Unix timestamp in seconds                     |
-| `modifiedAt` | `number?` | Resource modification time in Unix seconds; `null` on iOS |
-| `fileSize`   | `number`  | File size in bytes                                        |
+| Field        | Type      | Description                                                 |
+| ------------ | --------- | ----------------------------------------------------------- |
+| `id`         | `string`  | Unique identifier                                           |
+| `title`      | `string`  | Track title                                                 |
+| `artist`     | `string`  | Artist name                                                 |
+| `artwork`    | `string?` | Artwork file URI (may be undefined)                         |
+| `album`      | `string`  | Album name                                                  |
+| `duration`   | `number`  | Duration in seconds                                         |
+| `url`        | `string`  | Playable URI; preserves `file://` when available on Android |
+| `contentUri` | `string?` | Canonical Android MediaStore URI                            |
+| `createdAt`  | `number?` | Date added, Unix timestamp in seconds                       |
+| `modifiedAt` | `number?` | Resource modification time in Unix seconds; `null` on iOS   |
+| `fileSize`   | `number`  | File size in bytes                                          |
+
+### Android Track resources
+
+Use `contentUri` as the canonical Android Track resource. `url` remains
+backward compatible: it is a `file://` URI when MediaStore exposes a legacy
+path, and otherwise falls back to the same playable `content://` URI. Track
+Metadata is opened through `ContentResolver`, so a Track no longer requires a
+`DATA` path.
+
+`directory` still accepts an absolute path for existing callers. On Android 10+
+it also accepts a Storage Access Framework tree URI from the system external
+storage provider, including mounted removable volumes; filtering uses the
+MediaStore volume and relative path. Other document providers and SAF tree URIs
+on older Android versions reject with `UNSUPPORTED_DIRECTORY_URI` instead of
+guessing a `/storage/...` path.
 
 ### `TrackMetadata`
 

--- a/README.md
+++ b/README.md
@@ -191,19 +191,19 @@ getArtistsAsync(options?: ArtistOptions): Promise<PaginatedResult<Artist>>
 
 ### `Track`
 
-| Field        | Type      | Description                                                 |
-| ------------ | --------- | ----------------------------------------------------------- |
-| `id`         | `string`  | Unique identifier                                           |
-| `title`      | `string`  | Track title                                                 |
-| `artist`     | `string`  | Artist name                                                 |
-| `artwork`    | `string?` | Artwork file URI (may be undefined)                         |
-| `album`      | `string`  | Album name                                                  |
-| `duration`   | `number`  | Duration in seconds                                         |
-| `url`        | `string`  | Playable URI; preserves `file://` when available on Android |
-| `contentUri` | `string?` | Canonical Android MediaStore URI                            |
-| `createdAt`  | `number?` | Date added, Unix timestamp in seconds                       |
-| `modifiedAt` | `number?` | Resource modification time in Unix seconds; `null` on iOS   |
-| `fileSize`   | `number`  | File size in bytes                                          |
+| Field        | Type             | Description                                                 |
+| ------------ | ---------------- | ----------------------------------------------------------- |
+| `id`         | `string`         | Unique identifier                                           |
+| `title`      | `string`         | Track title                                                 |
+| `artist`     | `string \| null` | Artist name, or `null`                                      |
+| `artwork`    | `string \| null` | Artwork reference, or `null`                                |
+| `album`      | `string \| null` | Album name, or `null`                                       |
+| `duration`   | `number`         | Duration in seconds                                         |
+| `url`        | `string`         | Playable URI; preserves `file://` when available on Android |
+| `contentUri` | `string?`        | Canonical Android MediaStore URI                            |
+| `createdAt`  | `number \| null` | Date added, Unix timestamp in seconds, or `null`            |
+| `modifiedAt` | `number \| null` | Resource modification time in Unix seconds; `null` on iOS   |
+| `fileSize`   | `number`         | File size in bytes                                          |
 
 ### Android Track resources
 
@@ -222,37 +222,37 @@ guessing a `/storage/...` path.
 
 ### `TrackMetadata`
 
-| Field         | Type     | Description                          |
-| ------------- | -------- | ------------------------------------ |
-| `id`          | `string` | Track ID                             |
-| `duration`    | `number` | Duration in seconds                  |
-| `bitrate`     | `number` | Bitrate in kbps                      |
-| `sampleRate`  | `number` | Sample rate in Hz                    |
-| `channels`    | `string` | Number of audio channels             |
-| `format`      | `string` | Audio format (e.g. `"AAC"`, `"MP3"`) |
-| `title`       | `string` | Title tag                            |
-| `artist`      | `string` | Artist tag                           |
-| `album`       | `string` | Album tag                            |
-| `year`        | `number` | Release year                         |
-| `genre`       | `string` | Genre tag                            |
-| `track`       | `number` | Track number                         |
-| `disc`        | `number` | Disc number                          |
-| `composer`    | `string` | Composer tag                         |
-| `lyricist`    | `string` | Lyricist tag                         |
-| `lyrics`      | `string` | Embedded lyrics                      |
-| `albumArtist` | `string` | Album artist tag                     |
-| `comment`     | `string` | Comment tag                          |
+| Field         | Type             | Description                         |
+| ------------- | ---------------- | ----------------------------------- |
+| `id`          | `string`         | Track ID                            |
+| `duration`    | `number \| null` | Duration in seconds, or `null`      |
+| `bitrate`     | `number \| null` | Bitrate in kbps, or `null`          |
+| `sampleRate`  | `number \| null` | Sample rate in Hz, or `null`        |
+| `channels`    | `string \| null` | Number of audio channels, or `null` |
+| `format`      | `string \| null` | Audio format, or `null`             |
+| `title`       | `string \| null` | Title tag, or `null`                |
+| `artist`      | `string \| null` | Artist tag, or `null`               |
+| `album`       | `string \| null` | Album tag, or `null`                |
+| `year`        | `number \| null` | Release year, or `null`             |
+| `genre`       | `string \| null` | Genre tag, or `null`                |
+| `track`       | `number \| null` | Track number, or `null`             |
+| `disc`        | `number \| null` | Disc number, or `null`              |
+| `composer`    | `string \| null` | Composer tag, or `null`             |
+| `lyricist`    | `string \| null` | Lyricist tag, or `null`             |
+| `lyrics`      | `string \| null` | Embedded lyrics, or `null`          |
+| `albumArtist` | `string \| null` | Album artist tag, or `null`         |
+| `comment`     | `string \| null` | Comment tag, or `null`              |
 
 ### `Album`
 
-| Field        | Type      | Description                    |
-| ------------ | --------- | ------------------------------ |
-| `id`         | `string`  | Unique identifier              |
-| `title`      | `string`  | Album name                     |
-| `artist`     | `string`  | Primary artist                 |
-| `artwork`    | `string?` | Artwork URI (may be undefined) |
-| `trackCount` | `number`  | Number of tracks               |
-| `year`       | `number?` | Release year                   |
+| Field        | Type             | Description                  |
+| ------------ | ---------------- | ---------------------------- |
+| `id`         | `string`         | Unique identifier            |
+| `title`      | `string`         | Album name                   |
+| `artist`     | `string`         | Primary artist               |
+| `artwork`    | `string \| null` | Artwork reference, or `null` |
+| `trackCount` | `number`         | Number of tracks             |
+| `year`       | `number \| null` | Release year, or `null`      |
 
 ### `Artist`
 
@@ -301,6 +301,27 @@ For workflows that need the complete current result, use
 `getAllTracksAsync`, `getAllTracksByArtistAsync`, `getAllAlbumsAsync`, or
 `getAllArtistsAsync`. These helpers follow `endCursor`, preserve the low-level
 query options, and reject malformed or non-advancing native pagination.
+
+## Result and error contract
+
+Nullable `Track`, `Album`, and `TrackMetadata` fields are always present and
+use `null` when the Local Music Library does not provide a value. Structural
+optional fields are omitted: `contentUri` is Android-only, and a terminal page
+does not contain `endCursor`. Missing or unreadable Embedded Metadata resolves
+with the available Library Metadata and `null` values.
+
+Native failures reject the Promise with a `MusicLibraryError` and one of these
+stable codes:
+
+| Code                        | Meaning                                                   |
+| --------------------------- | --------------------------------------------------------- |
+| `PERMISSION_DENIED`         | Local Music Library access is not authorized              |
+| `TRACK_NOT_FOUND`           | The requested Track no longer exists                      |
+| `QUERY_ERROR`               | The platform library query or resource read failed        |
+| `INVALID_CURSOR`            | `after` is not a valid entity-ID cursor                   |
+| `CURSOR_NOT_FOUND`          | The cursor is valid but absent from this query            |
+| `INVALID_PAGE_SIZE`         | `first` is outside `1`–`1000`                             |
+| `UNSUPPORTED_DIRECTORY_URI` | Android cannot safely map the directory URI to MediaStore |
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -94,12 +94,16 @@ getTracksAsync(options?: TrackOptions): Promise<PaginatedResult<Track>>
 
 | Property    | Type                                                     | Default     | Description                             |
 | ----------- | -------------------------------------------------------- | ----------- | --------------------------------------- |
-| `first`     | `number`                                                 | `20`        | Max number of items to return           |
+| `first`     | `number`                                                 | `20`        | Items to return (`1`–`1000`)            |
 | `after`     | `string`                                                 | —           | Cursor from previous page's `endCursor` |
 | `sortBy`    | `TrackSortByKey \| [TrackSortByKey, boolean] \| (...)[]` | `'default'` | Sort key, or tuple `[key, ascending]`   |
 | `directory` | `string`                                                 | —           | Filter by directory path (Android only) |
 
 **TrackSortByKey**: `'default' \| 'title' \| 'artist' \| 'album' \| 'duration' \| 'createdAt' \| 'modifiedAt' \| 'fileSize'`
+
+The default sort is title ascending. A bare sort key such as `sortBy: 'artist'`
+means descending; use `[key, true]` for ascending. Multiple descriptors are
+applied in order, with the entity ID used as a final ascending tie-breaker.
 
 ---
 
@@ -145,7 +149,7 @@ getAlbumsAsync(options?: AlbumOptions): Promise<PaginatedResult<Album>>
 
 | Property | Type                                                     | Default     | Description                             |
 | -------- | -------------------------------------------------------- | ----------- | --------------------------------------- |
-| `first`  | `number`                                                 | `20`        | Max number of items to return           |
+| `first`  | `number`                                                 | `20`        | Items to return (`1`–`1000`)            |
 | `after`  | `string`                                                 | —           | Cursor from previous page's `endCursor` |
 | `sortBy` | `AlbumSortByKey \| [AlbumSortByKey, boolean] \| (...)[]` | `'default'` | Sort key, or tuple `[key, ascending]`   |
 
@@ -175,7 +179,7 @@ getArtistsAsync(options?: ArtistOptions): Promise<PaginatedResult<Artist>>
 
 | Property | Type                                                       | Default     | Description                             |
 | -------- | ---------------------------------------------------------- | ----------- | --------------------------------------- |
-| `first`  | `number`                                                   | `20`        | Max number of items to return           |
+| `first`  | `number`                                                   | `20`        | Items to return (`1`–`1000`)            |
 | `after`  | `string`                                                   | —           | Cursor from previous page's `endCursor` |
 | `sortBy` | `ArtistSortByKey \| [ArtistSortByKey, boolean] \| (...)[]` | `'default'` | Sort key, or tuple `[key, ascending]`   |
 
@@ -187,18 +191,18 @@ getArtistsAsync(options?: ArtistOptions): Promise<PaginatedResult<Artist>>
 
 ### `Track`
 
-| Field        | Type      | Description                         |
-| ------------ | --------- | ----------------------------------- |
-| `id`         | `string`  | Unique identifier                   |
-| `title`      | `string`  | Track title                         |
-| `artist`     | `string`  | Artist name                         |
-| `artwork`    | `string?` | Artwork file URI (may be undefined) |
-| `album`      | `string`  | Album name                          |
-| `duration`   | `number`  | Duration in seconds                 |
-| `url`        | `string`  | File URI                            |
-| `createdAt`  | `number`  | Unix timestamp (seconds)            |
-| `modifiedAt` | `number`  | Unix timestamp (seconds)            |
-| `fileSize`   | `number`  | File size in bytes                  |
+| Field        | Type      | Description                                               |
+| ------------ | --------- | --------------------------------------------------------- |
+| `id`         | `string`  | Unique identifier                                         |
+| `title`      | `string`  | Track title                                               |
+| `artist`     | `string`  | Artist name                                               |
+| `artwork`    | `string?` | Artwork file URI (may be undefined)                       |
+| `album`      | `string`  | Album name                                                |
+| `duration`   | `number`  | Duration in seconds                                       |
+| `url`        | `string`  | File URI                                                  |
+| `createdAt`  | `number?` | Date added, Unix timestamp in seconds                     |
+| `modifiedAt` | `number?` | Resource modification time in Unix seconds; `null` on iOS |
+| `fileSize`   | `number`  | File size in bytes                                        |
 
 ### `TrackMetadata`
 
@@ -251,6 +255,12 @@ getArtistsAsync(options?: ArtistOptions): Promise<PaginatedResult<Artist>>
 | `hasNextPage` | `boolean` | Whether more items are available          |
 | `endCursor`   | `string?` | Pass to `after` to fetch next page        |
 | `totalCount`  | `number?` | Total count (may be expensive to compute) |
+
+`endCursor` is the ID of the last returned entity. Reuse it only with the same
+entity, filters, and sort options. A malformed cursor rejects with
+`INVALID_CURSOR`; a valid ID absent from the current result rejects with
+`CURSOR_NOT_FOUND`. A cursor at the final entity returns an empty terminal page
+without a new `endCursor`.
 
 ---
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,6 +75,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation("net.jthink:jaudiotagger:3.0.1")
+  testImplementation "junit:junit:4.13.2"
 }
 
 react {

--- a/android/src/main/java/com/musiclibrary/albums/GetAlbums.kt
+++ b/android/src/main/java/com/musiclibrary/albums/GetAlbums.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.facebook.react.bridge.Promise
 import com.musiclibrary.models.AlbumOptions
 import com.musiclibrary.utils.DataConverter
+import com.musiclibrary.utils.rejectQueryError
 
 internal class GetAlbums(
   private val context: Context,
@@ -22,7 +23,7 @@ internal class GetAlbums(
 
       promise.resolve(writableMap)
     } catch (e: Exception) {
-      promise.reject("QUERY_ERROR", "Failed to query albums: ${e.message}", e)
+      promise.rejectQueryError(e, "Failed to query albums")
     }
   }
 }

--- a/android/src/main/java/com/musiclibrary/albums/GetAlbumsByArtist.kt
+++ b/android/src/main/java/com/musiclibrary/albums/GetAlbumsByArtist.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.Arguments
 import com.musiclibrary.utils.DataConverter
+import com.musiclibrary.utils.rejectQueryError
 
 internal class GetAlbumsByArtist(
   private val context: Context,
@@ -24,7 +25,7 @@ internal class GetAlbumsByArtist(
 
       promise.resolve(albumsArray)
     } catch (e: Exception) {
-      promise.reject("QUERY_ERROR", "Failed to query albums by artist: ${e.message}", e)
+      promise.rejectQueryError(e, "Failed to query albums by artist")
     }
   }
 }

--- a/android/src/main/java/com/musiclibrary/albums/GetAlbumsQuery.kt
+++ b/android/src/main/java/com/musiclibrary/albums/GetAlbumsQuery.kt
@@ -2,17 +2,18 @@ package com.musiclibrary.albums
 
 import android.content.ContentResolver
 import android.provider.MediaStore
-import android.net.Uri
-import android.provider.DocumentsContract
 import com.musiclibrary.models.*
+import com.musiclibrary.utils.moveToPageStart
 import com.musiclibrary.utils.readCursorPage
-import androidx.core.net.toUri
+import com.musiclibrary.utils.validatePageSize
 
 object GetAlbumsQuery {
   fun getAlbums(
     contentResolver: ContentResolver,
     options: AlbumOptions,
   ): PaginatedResult<Album> {
+    validatePageSize(options.first)
+
     val projection = arrayOf(
       MediaStore.Audio.Albums._ID,
       MediaStore.Audio.Albums.ALBUM,
@@ -23,7 +24,7 @@ object GetAlbumsQuery {
 
     val selection = buildSelection(options)
     val selectionArgs = buildSelectionArgs(options)
-    val sortOrder = buildSortOrder(options.sortBy)
+    val sortOrder = buildAlbumSortOrder(options.sortBy)
 
     val cursor = contentResolver.query(
       MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI,
@@ -42,29 +43,16 @@ object GetAlbumsQuery {
       val trackCountColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Albums.NUMBER_OF_SONGS)
       val firstYearColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Albums.FIRST_YEAR)
 
-      // Jump to the specified start position
-      val foundAfter = if (options.after == null) {
-        cursor.moveToFirst() // Move to the first record
-        true
-      } else {
-        var found = false
-        if (cursor.moveToFirst()) {
-          do {
-            val id = cursor.getLong(idColumn).toString()
-            if (id == options.after) {
-              found = true
-              break
-            }
-          } while (cursor.moveToNext())
-        }
-        // Move to the next record after the specified after if found
-        found && cursor.moveToNext()
-      }
+      val foundAfter = moveToPageStart(
+        after = options.after,
+        moveToFirst = c::moveToFirst,
+        currentId = { c.getLong(idColumn).toString() },
+        moveToNext = c::moveToNext,
+      )
 
-      val maxItems = options.first.coerceAtMost(1000) // Limit the maximum number of queries
       val page = readCursorPage(
         canReadFirst = foundAfter,
-        maxItems = maxItems,
+        maxItems = options.first,
         readItem = {
           val id = c.getLong(idColumn)
           val albumTitle = c.getString(albumColumn) ?: ""
@@ -77,14 +65,12 @@ object GetAlbumsQuery {
             null
           } else {
             // Get artwork URI
-            val artworkUri: Uri = "content://media/external/audio/albumart/${id}".toUri()
-
             // Create an Album
             Album(
               id = id.toString(),
               title = albumTitle,
               artist = artist,
-              artwork = artworkUri.toString(),
+              artwork = "content://media/external/audio/albumart/$id",
               trackCount = trackCount,
               year = if (firstYear > 0) firstYear else null
             )
@@ -116,26 +102,9 @@ object GetAlbumsQuery {
     return null
   }
 
-  private fun uriToFullPath(treeUri: Uri): String? {
-    val docId = DocumentsContract.getTreeDocumentId(treeUri) // "primary:Music/abc"
-    val parts = docId.split(":")
-    if (parts.size < 2) return null
-
-    val type = parts[0]
-    val relativePath = parts[1]
-
-    return when (type) {
-      "primary" -> "/storage/emulated/0/$relativePath"
-      else -> "/storage/$type/$relativePath"
-    }
-  }
-
-  private fun buildSortOrder(sortBy: List<SortOption>): String {
-    if (sortBy.isEmpty()) {
-      return "${MediaStore.Audio.Albums.ALBUM} ASC"
-    }
-
-    return sortBy.joinToString(", ") { sortOption ->
+  internal fun buildAlbumSortOrder(sortBy: List<SortOption>): String {
+    val options = sortBy.ifEmpty { listOf(SortOption("default", true)) }
+    val descriptors = options.map { sortOption ->
       val column = when (sortOption.key.lowercase()) {
         "default" -> MediaStore.Audio.Albums.ALBUM
         "title" -> MediaStore.Audio.Albums.ALBUM
@@ -148,5 +117,7 @@ object GetAlbumsQuery {
       val order = if (sortOption.ascending) "ASC" else "DESC"
       "$column $order"
     }
+
+    return (descriptors + "${MediaStore.Audio.Albums._ID} ASC").joinToString(", ")
   }
 }

--- a/android/src/main/java/com/musiclibrary/albums/GetAlbumsQuery.kt
+++ b/android/src/main/java/com/musiclibrary/albums/GetAlbumsQuery.kt
@@ -5,6 +5,7 @@ import android.provider.MediaStore
 import android.net.Uri
 import android.provider.DocumentsContract
 import com.musiclibrary.models.*
+import com.musiclibrary.utils.readCursorPage
 import androidx.core.net.toUri
 
 object GetAlbumsQuery {
@@ -32,12 +33,9 @@ object GetAlbumsQuery {
       sortOrder
     ) ?: throw RuntimeException("Failed to query MediaStore: cursor is null")
 
-    val albums = mutableListOf<Album>()
-    var hasNextPage: Boolean
-    var endCursor: String? = null
     val totalCount = cursor.count
 
-    cursor.use { c ->
+    return cursor.use { c ->
       val idColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Albums._ID)
       val albumColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Albums.ALBUM)
       val artistColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Albums.ARTIST)
@@ -63,11 +61,11 @@ object GetAlbumsQuery {
         found && cursor.moveToNext()
       }
 
-      var count = 0
       val maxItems = options.first.coerceAtMost(1000) // Limit the maximum number of queries
-
-      while (foundAfter && count < maxItems) {
-        try {
+      val page = readCursorPage(
+        canReadFirst = foundAfter,
+        maxItems = maxItems,
+        readItem = {
           val id = c.getLong(idColumn)
           val albumTitle = c.getString(albumColumn) ?: ""
           val artist = c.getString(artistColumn) ?: ""
@@ -76,42 +74,33 @@ object GetAlbumsQuery {
 
           // Skip invalid albums
           if (albumTitle.isEmpty() || trackCount == 0) {
-            continue
+            null
+          } else {
+            // Get artwork URI
+            val artworkUri: Uri = "content://media/external/audio/albumart/${id}".toUri()
+
+            // Create an Album
+            Album(
+              id = id.toString(),
+              title = albumTitle,
+              artist = artist,
+              artwork = artworkUri.toString(),
+              trackCount = trackCount,
+              year = if (firstYear > 0) firstYear else null
+            )
           }
+        },
+        moveToNext = c::moveToNext,
+        isAfterLast = { c.isAfterLast },
+      )
 
-          // Get artwork URI
-          val artworkUri: Uri = "content://media/external/audio/albumart/${id}".toUri()
-
-          // Create an Album
-          val album = Album(
-            id = id.toString(),
-            title = albumTitle,
-            artist = artist,
-            artwork = artworkUri.toString(),
-            trackCount = trackCount,
-            year = if (firstYear > 0) firstYear else null
-          )
-
-          albums.add(album)
-          endCursor = id.toString()
-          count++
-        } catch (e: Exception) {
-          continue
-        }
-
-        if (!cursor.moveToNext()) break
-      }
-
-      // Check if there are more data
-      hasNextPage = !c.isAfterLast
+      PaginatedResult(
+        items = page.items,
+        hasNextPage = page.hasNextPage,
+        endCursor = page.items.lastOrNull()?.id,
+        totalCount = totalCount
+      )
     }
-
-    return PaginatedResult(
-      items = albums,
-      hasNextPage = hasNextPage,
-      endCursor = endCursor,
-      totalCount = totalCount
-    )
   }
 
   private fun buildSelection(options: AlbumOptions): String {

--- a/android/src/main/java/com/musiclibrary/artists/GetArtists.kt
+++ b/android/src/main/java/com/musiclibrary/artists/GetArtists.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.facebook.react.bridge.Promise
 import com.musiclibrary.models.ArtistOptions
 import com.musiclibrary.utils.DataConverter
+import com.musiclibrary.utils.rejectQueryError
 
 internal class GetArtists(
   private val context: Context,
@@ -23,7 +24,7 @@ internal class GetArtists(
 
       promise.resolve(resultMap)
     } catch (e: Exception) {
-      promise.reject("QUERY_ERROR", "Failed to query artists: ${e.message}", e)
+      promise.rejectQueryError(e, "Failed to query artists")
     }
   }
 }

--- a/android/src/main/java/com/musiclibrary/artists/GetArtistsQuery.kt
+++ b/android/src/main/java/com/musiclibrary/artists/GetArtistsQuery.kt
@@ -5,6 +5,7 @@ import android.provider.MediaStore
 import android.net.Uri
 import android.provider.DocumentsContract
 import com.musiclibrary.models.*
+import com.musiclibrary.utils.readCursorPage
 import androidx.core.net.toUri
 
 object GetArtistsQuery {
@@ -31,12 +32,9 @@ object GetArtistsQuery {
       sortOrder
     ) ?: throw RuntimeException("Failed to query MediaStore: cursor is null")
 
-    val artists = mutableListOf<Artist>()
-    var hasNextPage: Boolean
-    var endCursor: String? = null
     val totalCount = cursor.count
 
-    cursor.use { c ->
+    return cursor.use { c ->
       val idColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Artists._ID)
       val artistColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Artists.ARTIST)
       val albumCountColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Artists.NUMBER_OF_ALBUMS)
@@ -61,11 +59,11 @@ object GetArtistsQuery {
         found && cursor.moveToNext()
       }
 
-      var count = 0
       val maxItems = options.first.coerceAtMost(1000) // Limit the maximum number of queries
-
-      while (foundAfter && count < maxItems) {
-        try {
+      val page = readCursorPage(
+        canReadFirst = foundAfter,
+        maxItems = maxItems,
+        readItem = {
           val id = c.getLong(idColumn)
           val artistName = c.getString(artistColumn) ?: ""
           val albumCount = c.getInt(albumCountColumn)
@@ -73,37 +71,28 @@ object GetArtistsQuery {
 
           // Skip invalid artists
           if (artistName.isEmpty() || trackCount == 0) {
-            continue
+            null
+          } else {
+            // Create an Artist
+            Artist(
+              id = id.toString(),
+              title = artistName,
+              albumCount = albumCount,
+              trackCount = trackCount
+            )
           }
+        },
+        moveToNext = c::moveToNext,
+        isAfterLast = { c.isAfterLast },
+      )
 
-          // Create an Artist
-          val artist = Artist(
-            id = id.toString(),
-            title = artistName,
-            albumCount = albumCount,
-            trackCount = trackCount
-          )
-
-          artists.add(artist)
-          endCursor = id.toString()
-          count++
-        } catch (e: Exception) {
-          continue
-        }
-
-        if (!cursor.moveToNext()) break
-      }
-
-      // Check if there are more data
-      hasNextPage = !c.isAfterLast
+      PaginatedResult(
+        items = page.items,
+        hasNextPage = page.hasNextPage,
+        endCursor = page.items.lastOrNull()?.id,
+        totalCount = totalCount
+      )
     }
-
-    return PaginatedResult(
-      items = artists,
-      hasNextPage = hasNextPage,
-      endCursor = endCursor,
-      totalCount = totalCount
-    )
   }
 
   private fun buildSelection(options: ArtistOptions): String {

--- a/android/src/main/java/com/musiclibrary/artists/GetArtistsQuery.kt
+++ b/android/src/main/java/com/musiclibrary/artists/GetArtistsQuery.kt
@@ -2,17 +2,18 @@ package com.musiclibrary.artists
 
 import android.content.ContentResolver
 import android.provider.MediaStore
-import android.net.Uri
-import android.provider.DocumentsContract
 import com.musiclibrary.models.*
+import com.musiclibrary.utils.moveToPageStart
 import com.musiclibrary.utils.readCursorPage
-import androidx.core.net.toUri
+import com.musiclibrary.utils.validatePageSize
 
 object GetArtistsQuery {
   fun getArtists(
     contentResolver: ContentResolver,
     options: ArtistOptions,
   ): PaginatedResult<Artist> {
+    validatePageSize(options.first)
+
     val projection = arrayOf(
       MediaStore.Audio.Artists._ID,
       MediaStore.Audio.Artists.ARTIST,
@@ -22,7 +23,7 @@ object GetArtistsQuery {
 
     val selection = buildSelection(options)
     val selectionArgs = buildSelectionArgs(options)
-    val sortOrder = buildSortOrder(options.sortBy)
+    val sortOrder = buildArtistSortOrder(options.sortBy)
 
     val cursor = contentResolver.query(
       MediaStore.Audio.Artists.EXTERNAL_CONTENT_URI,
@@ -40,29 +41,16 @@ object GetArtistsQuery {
       val albumCountColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Artists.NUMBER_OF_ALBUMS)
       val trackCountColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Artists.NUMBER_OF_TRACKS)
 
-      // Jump to the specified start position
-      val foundAfter = if (options.after == null) {
-        cursor.moveToFirst() // Move to the first record
-        true
-      } else {
-        var found = false
-        if (cursor.moveToFirst()) {
-          do {
-            val id = cursor.getLong(idColumn).toString()
-            if (id == options.after) {
-              found = true
-              break
-            }
-          } while (cursor.moveToNext())
-        }
-        // Move to the next record after the specified after if found
-        found && cursor.moveToNext()
-      }
+      val foundAfter = moveToPageStart(
+        after = options.after,
+        moveToFirst = c::moveToFirst,
+        currentId = { c.getLong(idColumn).toString() },
+        moveToNext = c::moveToNext,
+      )
 
-      val maxItems = options.first.coerceAtMost(1000) // Limit the maximum number of queries
       val page = readCursorPage(
         canReadFirst = foundAfter,
-        maxItems = maxItems,
+        maxItems = options.first,
         readItem = {
           val id = c.getLong(idColumn)
           val artistName = c.getString(artistColumn) ?: ""
@@ -108,12 +96,9 @@ object GetArtistsQuery {
     return null
   }
 
-  private fun buildSortOrder(sortBy: List<SortOption>): String {
-    if (sortBy.isEmpty()) {
-      return "${MediaStore.Audio.Artists.ARTIST} ASC"
-    }
-
-    return sortBy.joinToString(", ") { sortOption ->
+  internal fun buildArtistSortOrder(sortBy: List<SortOption>): String {
+    val options = sortBy.ifEmpty { listOf(SortOption("default", true)) }
+    val descriptors = options.map { sortOption ->
       val column = when (sortOption.key.lowercase()) {
         "default" -> MediaStore.Audio.Artists.ARTIST
         "title" -> MediaStore.Audio.Artists.ARTIST
@@ -125,5 +110,7 @@ object GetArtistsQuery {
       val order = if (sortOption.ascending) "ASC" else "DESC"
       "$column $order"
     }
+
+    return (descriptors + "${MediaStore.Audio.Artists._ID} ASC").joinToString(", ")
   }
 }

--- a/android/src/main/java/com/musiclibrary/models/Assets.kt
+++ b/android/src/main/java/com/musiclibrary/models/Assets.kt
@@ -8,6 +8,7 @@ data class Track(
   val album: String? = null,
   val duration: Double,
   val url: String,
+  val contentUri: String? = null,
   val createdAt: Long? = null,
   val modifiedAt: Long? = null,
   val fileSize: Long,

--- a/android/src/main/java/com/musiclibrary/tracks/AudioMetadataExtractor.kt
+++ b/android/src/main/java/com/musiclibrary/tracks/AudioMetadataExtractor.kt
@@ -1,19 +1,28 @@
 package com.musiclibrary.tracks
 
+import android.content.Context
 import com.musiclibrary.models.TrackMetadata
 import java.io.File
 import org.jaudiotagger.audio.AudioFileIO
 import org.jaudiotagger.tag.FieldKey
 
 internal object AudioMetadataExtractor {
-  fun extract(source: TrackMetadataSource): TrackMetadata {
-    val filePath = source.filePath
-    if (filePath.isNullOrEmpty()) {
-      return TrackMetadata(id = source.trackId)
-    }
-
+  fun extract(context: Context, source: TrackMetadataSource): TrackMetadata {
+    var temporaryFile: File? = null
     return try {
-      val audioFile = AudioFileIO.read(File(filePath))
+      val file = File.createTempFile(
+        "music-library-metadata-",
+        fileSuffix(source.displayName, source.mimeType),
+        context.cacheDir,
+      )
+      temporaryFile = file
+      val input = context.contentResolver.openInputStream(source.contentUri)
+        ?: return TrackMetadata(id = source.trackId)
+      input.use { stream ->
+        file.outputStream().use { output -> stream.copyTo(output) }
+      }
+
+      val audioFile = AudioFileIO.read(file)
       val header = audioFile.audioHeader
       val tag = audioFile.tag
 
@@ -39,6 +48,29 @@ internal object AudioMetadataExtractor {
       )
     } catch (_: Exception) {
       TrackMetadata(id = source.trackId)
+    } finally {
+      temporaryFile?.delete()
+    }
+  }
+
+  internal fun fileSuffix(displayName: String?, mimeType: String?): String {
+    val extension = displayName
+      ?.substringAfterLast('.', missingDelimiterValue = "")
+      ?.lowercase()
+      ?.takeIf { it.matches(Regex("[a-z0-9]{1,10}")) }
+
+    if (extension != null) {
+      return ".$extension"
+    }
+
+    return when (mimeType?.lowercase()) {
+      "audio/aac", "audio/aacp" -> ".aac"
+      "audio/flac" -> ".flac"
+      "audio/mp4", "audio/m4a", "audio/x-m4a" -> ".m4a"
+      "audio/mpeg" -> ".mp3"
+      "audio/ogg" -> ".ogg"
+      "audio/wav", "audio/x-wav" -> ".wav"
+      else -> ".audio"
     }
   }
 }

--- a/android/src/main/java/com/musiclibrary/tracks/GetTrackMetadataQuery.kt
+++ b/android/src/main/java/com/musiclibrary/tracks/GetTrackMetadataQuery.kt
@@ -13,7 +13,7 @@ internal class GetTrackMetadataQuery(
     try {
       val source = TrackMetadataLookup.findTrack(context.contentResolver, trackId)
         ?: throw TrackNotFoundException(trackId)
-      val result = AudioMetadataExtractor.extract(source)
+      val result = AudioMetadataExtractor.extract(context, source)
       val writableMap = DataConverter.trackMetadataToWritableMap(result)
       promise.resolve(writableMap)
     } catch (e: TrackNotFoundException) {

--- a/android/src/main/java/com/musiclibrary/tracks/GetTrackMetadataQuery.kt
+++ b/android/src/main/java/com/musiclibrary/tracks/GetTrackMetadataQuery.kt
@@ -3,6 +3,7 @@ package com.musiclibrary.tracks
 import android.content.Context
 import com.facebook.react.bridge.Promise
 import com.musiclibrary.utils.DataConverter
+import com.musiclibrary.utils.rejectQueryError
 
 internal class GetTrackMetadataQuery(
   private val context: Context,
@@ -19,7 +20,7 @@ internal class GetTrackMetadataQuery(
     } catch (e: TrackNotFoundException) {
       promise.reject("TRACK_NOT_FOUND", "Track with id $trackId not found", e)
     } catch (e: Exception) {
-      promise.reject("QUERY_ERROR", "Failed to get track metadata: ${e.message}", e)
+      promise.rejectQueryError(e, "Failed to get track metadata")
     }
   }
 }

--- a/android/src/main/java/com/musiclibrary/tracks/GetTracks.kt
+++ b/android/src/main/java/com/musiclibrary/tracks/GetTracks.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.facebook.react.bridge.Promise
 import com.musiclibrary.models.TrackOptions
 import com.musiclibrary.utils.DataConverter
+import com.musiclibrary.utils.rejectQueryError
 
 internal class GetTracks(
   private val context: Context,
@@ -22,7 +23,7 @@ internal class GetTracks(
 
       promise.resolve(writableMap)
     } catch (e: Exception) {
-      promise.reject("QUERY_ERROR", "Failed to query tracks: ${e.message}", e)
+      promise.rejectQueryError(e, "Failed to query tracks")
     }
   }
 }

--- a/android/src/main/java/com/musiclibrary/tracks/GetTracksByAlbum.kt
+++ b/android/src/main/java/com/musiclibrary/tracks/GetTracksByAlbum.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.Arguments
 import com.musiclibrary.utils.DataConverter
+import com.musiclibrary.utils.rejectQueryError
 
 internal class GetTracksByAlbum(
   private val context: Context,
@@ -24,7 +25,7 @@ internal class GetTracksByAlbum(
 
       promise.resolve(tracksArray)
     } catch (e: Exception) {
-      promise.reject("QUERY_ERROR", "Failed to query tracks by album: ${e.message}", e)
+      promise.rejectQueryError(e, "Failed to query tracks by album")
     }
   }
 }

--- a/android/src/main/java/com/musiclibrary/tracks/GetTracksByArtist.kt
+++ b/android/src/main/java/com/musiclibrary/tracks/GetTracksByArtist.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.facebook.react.bridge.Promise
 import com.musiclibrary.models.TrackOptions
 import com.musiclibrary.utils.DataConverter
+import com.musiclibrary.utils.rejectQueryError
 
 internal class GetTracksByArtist(
   private val context: Context,
@@ -24,7 +25,7 @@ internal class GetTracksByArtist(
 
       promise.resolve(resultMap)
     } catch (e: Exception) {
-      promise.reject("QUERY_ERROR", "Failed to query tracks by artist: ${e.message}", e)
+      promise.rejectQueryError(e, "Failed to query tracks by artist")
     }
   }
 }

--- a/android/src/main/java/com/musiclibrary/tracks/TrackDirectoryFilter.kt
+++ b/android/src/main/java/com/musiclibrary/tracks/TrackDirectoryFilter.kt
@@ -1,0 +1,90 @@
+package com.musiclibrary.tracks
+
+import android.os.Build
+import android.provider.DocumentsContract
+import android.provider.MediaStore
+import androidx.core.net.toUri
+import com.musiclibrary.utils.CodedQueryException
+
+internal data class TrackDirectorySelection(
+  val clause: String? = null,
+  val arguments: List<String> = emptyList(),
+)
+
+internal data class ExternalStorageDirectory(
+  val volumeName: String,
+  val relativePathPrefix: String?,
+)
+
+internal class UnsupportedDirectoryUriException(directory: String) : IllegalArgumentException(
+  "Directory URI is not a supported MediaStore-backed external storage tree: $directory",
+), CodedQueryException {
+  override val code = "UNSUPPORTED_DIRECTORY_URI"
+}
+
+internal object TrackDirectoryFilter {
+  fun resolve(directory: String?): TrackDirectorySelection {
+    if (directory.isNullOrEmpty()) {
+      return TrackDirectorySelection()
+    }
+
+    if (!directory.startsWith("content://", ignoreCase = true)) {
+      return TrackDirectorySelection(
+        clause = "${MediaStore.Audio.Media.DATA} LIKE ?",
+        arguments = listOf("$directory%"),
+      )
+    }
+
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      throw UnsupportedDirectoryUriException(directory)
+    }
+
+    val uri = directory.toUri()
+    if (
+      uri.authority != EXTERNAL_STORAGE_AUTHORITY ||
+      !DocumentsContract.isTreeUri(uri)
+    ) {
+      throw UnsupportedDirectoryUriException(directory)
+    }
+
+    val documentId = try {
+      DocumentsContract.getTreeDocumentId(uri)
+    } catch (_: IllegalArgumentException) {
+      throw UnsupportedDirectoryUriException(directory)
+    }
+    val parsed = parseExternalStorageDocumentId(documentId)
+      ?: throw UnsupportedDirectoryUriException(directory)
+
+    val relativePathPrefix = parsed.relativePathPrefix
+    return if (relativePathPrefix == null) {
+      TrackDirectorySelection(
+        clause = "${MediaStore.MediaColumns.VOLUME_NAME} = ?",
+        arguments = listOf(parsed.volumeName),
+      )
+    } else {
+      TrackDirectorySelection(
+        clause = "${MediaStore.MediaColumns.VOLUME_NAME} = ? AND ${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ?",
+        arguments = listOf(parsed.volumeName, relativePathPrefix),
+      )
+    }
+  }
+
+  internal fun parseExternalStorageDocumentId(documentId: String): ExternalStorageDirectory? {
+    val parts = documentId.split(":", limit = 2)
+    if (parts.isEmpty() || parts[0].isBlank()) {
+      return null
+    }
+
+    val volumeName = if (parts[0].equals("primary", ignoreCase = true)) {
+      MediaStore.VOLUME_EXTERNAL_PRIMARY
+    } else {
+      parts[0].lowercase()
+    }
+    val relativePath = parts.getOrNull(1)?.trim('/')?.takeIf { it.isNotEmpty() }
+    val prefix = relativePath?.let { "$it/%" }
+
+    return ExternalStorageDirectory(volumeName, prefix)
+  }
+
+  private const val EXTERNAL_STORAGE_AUTHORITY = "com.android.externalstorage.documents"
+}

--- a/android/src/main/java/com/musiclibrary/tracks/TrackMetadataLookup.kt
+++ b/android/src/main/java/com/musiclibrary/tracks/TrackMetadataLookup.kt
@@ -1,11 +1,15 @@
 package com.musiclibrary.tracks
 
 import android.content.ContentResolver
+import android.content.ContentUris
+import android.net.Uri
 import android.provider.MediaStore
 
 internal data class TrackMetadataSource(
   val trackId: String,
-  val filePath: String?,
+  val contentUri: Uri,
+  val displayName: String?,
+  val mimeType: String?,
 )
 
 internal object TrackMetadataLookup {
@@ -13,24 +17,33 @@ internal object TrackMetadataLookup {
     contentResolver: ContentResolver,
     trackId: String,
   ): TrackMetadataSource? {
-    val projection = arrayOf(MediaStore.Audio.Media.DATA)
-    val selection = "${MediaStore.Audio.Media._ID} = ?"
-    val selectionArgs = arrayOf(trackId)
+    val id = trackId.toLongOrNull() ?: return null
+    val contentUri = ContentUris.withAppendedId(
+      MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+      id,
+    )
+    val projection = arrayOf(
+      MediaStore.Audio.Media.DISPLAY_NAME,
+      MediaStore.Audio.Media.MIME_TYPE,
+    )
 
     val cursor = contentResolver.query(
-      MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+      contentUri,
       projection,
-      selection,
-      selectionArgs,
+      null,
+      null,
       null
     )
 
     cursor?.use { c ->
       if (c.moveToFirst()) {
-        val dataColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA)
+        val displayNameColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Media.DISPLAY_NAME)
+        val mimeTypeColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Media.MIME_TYPE)
         return TrackMetadataSource(
           trackId = trackId,
-          filePath = c.getString(dataColumn)
+          contentUri = contentUri,
+          displayName = c.getString(displayNameColumn),
+          mimeType = c.getString(mimeTypeColumn),
         )
       }
     }

--- a/android/src/main/java/com/musiclibrary/tracks/TrackQuery.kt
+++ b/android/src/main/java/com/musiclibrary/tracks/TrackQuery.kt
@@ -10,6 +10,8 @@ import com.musiclibrary.models.PaginatedResult
 import com.musiclibrary.models.SortOption
 import com.musiclibrary.models.Track
 import com.musiclibrary.models.TrackOptions
+import com.musiclibrary.utils.moveToPageStart
+import com.musiclibrary.utils.validatePageSize
 
 internal sealed class TrackQueryFilter {
   object All : TrackQueryFilter()
@@ -28,19 +30,26 @@ internal object TrackQuery {
     filter: TrackQueryFilter = TrackQueryFilter.All,
     options: TrackOptions,
   ): PaginatedResult<Track> {
+    validatePageSize(options.first)
+
     val cursor = queryTracks(
       contentResolver = contentResolver,
       filter = filter,
       directory = options.directory,
-      sortOrder = buildSortOrder(TrackSortPolicy.Options, options.sortBy)
+      sortOrder = buildTrackSortOrder(TrackSortPolicy.Options, options.sortBy)
     )
 
     cursor.use { c ->
       val columns = TrackColumns.from(c)
       val tracks = mutableListOf<Track>()
       var endCursor: String? = null
-      val canReadFirst = moveToPageStart(c, columns, options.after)
-      val maxItems = options.first.coerceAtMost(1000)
+      val canReadFirst = moveToPageStart(
+        after = options.after,
+        moveToFirst = c::moveToFirst,
+        currentId = { c.getLong(columns.id).toString() },
+        moveToNext = c::moveToNext,
+      )
+      val maxItems = options.first
       var count = 0
 
       while (canReadFirst && count < maxItems) {
@@ -73,7 +82,7 @@ internal object TrackQuery {
       contentResolver = contentResolver,
       filter = filter,
       directory = null,
-      sortOrder = buildSortOrder(sortPolicy, emptyList())
+      sortOrder = buildTrackSortOrder(sortPolicy, emptyList())
     )
 
     cursor.use { c ->
@@ -103,23 +112,6 @@ internal object TrackQuery {
     ) ?: throw RuntimeException("Failed to query MediaStore: cursor is null")
   }
 
-  private fun moveToPageStart(cursor: Cursor, columns: TrackColumns, after: String?): Boolean {
-    if (after == null) {
-      return cursor.moveToFirst()
-    }
-
-    if (cursor.moveToFirst()) {
-      do {
-        val id = cursor.getLong(columns.id).toString()
-        if (id == after) {
-          return cursor.moveToNext()
-        }
-      } while (cursor.moveToNext())
-    }
-
-    return false
-  }
-
   private fun readTrack(cursor: Cursor, columns: TrackColumns): Track? {
     return try {
       val id = cursor.getLong(columns.id)
@@ -134,6 +126,7 @@ internal object TrackQuery {
       val album = cursor.getString(columns.album)
       val duration = cursor.getLong(columns.duration) / 1000.0
       val dateAdded = cursor.getLong(columns.dateAdded)
+      val dateModified = cursor.getLong(columns.dateModified)
       val fileSize = cursor.getLong(columns.size)
 
       Track(
@@ -144,8 +137,8 @@ internal object TrackQuery {
         album = album,
         duration = duration,
         url = "file://$data",
-        createdAt = dateAdded * 1000,
-        modifiedAt = dateAdded * 1000,
+        createdAt = dateAdded,
+        modifiedAt = dateModified,
         fileSize = fileSize
       )
     } catch (_: Exception) {
@@ -196,13 +189,13 @@ internal object TrackQuery {
     return if (args.isEmpty()) null else args.toTypedArray()
   }
 
-  private fun buildSortOrder(sortPolicy: TrackSortPolicy, sortBy: List<SortOption>): String {
+  internal fun buildTrackSortOrder(sortPolicy: TrackSortPolicy, sortBy: List<SortOption>): String {
     if (sortPolicy == TrackSortPolicy.AlbumTrackNumber) {
-      return "${MediaStore.Audio.Media.TRACK} ASC, ${MediaStore.Audio.Media.TITLE} ASC"
+      return "${MediaStore.Audio.Media.TRACK} ASC, ${MediaStore.Audio.Media.TITLE} ASC, ${MediaStore.Audio.Media._ID} ASC"
     }
 
     val options = sortBy.ifEmpty { listOf(SortOption("default", true)) }
-    return options.joinToString(", ") { sortOption ->
+    val descriptors = options.map { sortOption ->
       val column = when (sortOption.key.lowercase()) {
         "default" -> MediaStore.Audio.Media.TITLE
         "title" -> MediaStore.Audio.Media.TITLE
@@ -218,6 +211,8 @@ internal object TrackQuery {
       val order = if (sortOption.ascending) "ASC" else "DESC"
       "$column $order"
     }
+
+    return (descriptors + "${MediaStore.Audio.Media._ID} ASC").joinToString(", ")
   }
 
   private fun uriToFullPath(treeUri: Uri): String? {
@@ -246,6 +241,7 @@ internal object TrackQuery {
     val duration: Int,
     val data: Int,
     val dateAdded: Int,
+    val dateModified: Int,
     val size: Int,
   ) {
     companion object {
@@ -258,6 +254,7 @@ internal object TrackQuery {
           duration = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION),
           data = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA),
           dateAdded = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED),
+          dateModified = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_MODIFIED),
           size = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.SIZE)
         )
       }
@@ -272,6 +269,7 @@ internal object TrackQuery {
     MediaStore.Audio.Media.DURATION,
     MediaStore.Audio.Media.DATA,
     MediaStore.Audio.Media.DATE_ADDED,
+    MediaStore.Audio.Media.DATE_MODIFIED,
     MediaStore.Audio.Media.SIZE,
     MediaStore.Audio.Media.ALBUM_ID,
     MediaStore.Audio.Media.TRACK

--- a/android/src/main/java/com/musiclibrary/tracks/TrackQuery.kt
+++ b/android/src/main/java/com/musiclibrary/tracks/TrackQuery.kt
@@ -1,11 +1,9 @@
 package com.musiclibrary.tracks
 
 import android.content.ContentResolver
+import android.content.ContentUris
 import android.database.Cursor
-import android.net.Uri
-import android.provider.DocumentsContract
 import android.provider.MediaStore
-import androidx.core.net.toUri
 import com.musiclibrary.models.PaginatedResult
 import com.musiclibrary.models.SortOption
 import com.musiclibrary.models.Track
@@ -103,11 +101,12 @@ internal object TrackQuery {
     directory: String?,
     sortOrder: String,
   ): Cursor {
+    val directorySelection = TrackDirectoryFilter.resolve(directory)
     return contentResolver.query(
       MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
       TRACK_PROJECTION,
-      buildSelection(filter, directory),
-      buildSelectionArgs(filter, directory),
+      buildSelection(filter, directorySelection),
+      buildSelectionArgs(filter, directorySelection),
       sortOrder
     ) ?: throw RuntimeException("Failed to query MediaStore: cursor is null")
   }
@@ -115,11 +114,11 @@ internal object TrackQuery {
   private fun readTrack(cursor: Cursor, columns: TrackColumns): Track? {
     return try {
       val id = cursor.getLong(columns.id)
-      val data = cursor.getString(columns.data) ?: return null
-
-      if (data.isEmpty()) {
-        return null
-      }
+      val data = cursor.getString(columns.data)?.takeIf { it.isNotEmpty() }
+      val contentUri = ContentUris.withAppendedId(
+        MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+        id,
+      ).toString()
 
       val title = cursor.getString(columns.title) ?: ""
       val artist = cursor.getString(columns.artist)
@@ -136,7 +135,8 @@ internal object TrackQuery {
         artwork = artworkUri(id),
         album = album,
         duration = duration,
-        url = "file://$data",
+        url = selectTrackUrl(contentUri, data),
+        contentUri = contentUri,
         createdAt = dateAdded,
         modifiedAt = dateModified,
         fileSize = fileSize
@@ -146,7 +146,10 @@ internal object TrackQuery {
     }
   }
 
-  private fun buildSelection(filter: TrackQueryFilter, directory: String?): String {
+  private fun buildSelection(
+    filter: TrackQueryFilter,
+    directory: TrackDirectorySelection,
+  ): String {
     val conditions = mutableListOf<String>()
 
     when (filter) {
@@ -158,14 +161,15 @@ internal object TrackQuery {
     conditions.add("${MediaStore.Audio.Media.IS_MUSIC} = 1")
     conditions.add("${MediaStore.Audio.Media.DURATION} > 0")
 
-    if (!directory.isNullOrEmpty()) {
-      conditions.add("${MediaStore.Audio.Media.DATA} LIKE ?")
-    }
+    directory.clause?.let { conditions.add(it) }
 
     return conditions.joinToString(" AND ")
   }
 
-  private fun buildSelectionArgs(filter: TrackQueryFilter, directory: String?): Array<String>? {
+  private fun buildSelectionArgs(
+    filter: TrackQueryFilter,
+    directory: TrackDirectorySelection,
+  ): Array<String>? {
     val args = mutableListOf<String>()
 
     when (filter) {
@@ -174,17 +178,7 @@ internal object TrackQuery {
       TrackQueryFilter.All -> Unit
     }
 
-    if (!directory.isNullOrEmpty()) {
-      val dir = if (directory.startsWith("content://")) {
-        uriToFullPath(directory.toUri())
-      } else {
-        directory
-      }
-
-      if (!dir.isNullOrEmpty()) {
-        args.add("$dir%")
-      }
-    }
+    args.addAll(directory.arguments)
 
     return if (args.isEmpty()) null else args.toTypedArray()
   }
@@ -215,22 +209,12 @@ internal object TrackQuery {
     return (descriptors + "${MediaStore.Audio.Media._ID} ASC").joinToString(", ")
   }
 
-  private fun uriToFullPath(treeUri: Uri): String? {
-    val docId = DocumentsContract.getTreeDocumentId(treeUri)
-    val parts = docId.split(":")
-    if (parts.size < 2) return null
-
-    val type = parts[0]
-    val relativePath = parts[1]
-
-    return when (type) {
-      "primary" -> "/storage/emulated/0/$relativePath"
-      else -> "/storage/$type/$relativePath"
-    }
-  }
-
   private fun artworkUri(id: Long): String {
     return "content://media/external/audio/media/$id/albumart"
+  }
+
+  internal fun selectTrackUrl(contentUri: String, filePath: String?): String {
+    return filePath?.takeIf { it.isNotEmpty() }?.let { "file://$it" } ?: contentUri
   }
 
   private data class TrackColumns(

--- a/android/src/main/java/com/musiclibrary/utils/CursorPageReader.kt
+++ b/android/src/main/java/com/musiclibrary/utils/CursorPageReader.kt
@@ -1,0 +1,32 @@
+package com.musiclibrary.utils
+
+internal data class CursorPage<T>(
+  val items: List<T>,
+  val hasNextPage: Boolean,
+)
+
+internal fun <T> readCursorPage(
+  canReadFirst: Boolean,
+  maxItems: Int,
+  readItem: () -> T?,
+  moveToNext: () -> Boolean,
+  isAfterLast: () -> Boolean,
+): CursorPage<T> {
+  val items = mutableListOf<T>()
+  var canReadCurrent = canReadFirst
+
+  while (canReadCurrent && items.size < maxItems) {
+    try {
+      readItem()?.let(items::add)
+    } catch (_: Exception) {
+      // Skip rows that cannot be converted, but always advance below.
+    }
+
+    canReadCurrent = moveToNext()
+  }
+
+  return CursorPage(
+    items = items,
+    hasNextPage = !isAfterLast(),
+  )
+}

--- a/android/src/main/java/com/musiclibrary/utils/DataConverter.kt
+++ b/android/src/main/java/com/musiclibrary/utils/DataConverter.kt
@@ -15,6 +15,7 @@ object DataConverter {
     track.album?.let { map.putString("album", it) }
     map.putDouble("duration", track.duration)
     map.putString("url", track.url)
+    track.contentUri?.let { map.putString("contentUri", it) }
     map.putLong("fileSize", track.fileSize)
 
     track.createdAt?.let { map.putDouble("createdAt", it.toDouble()) }

--- a/android/src/main/java/com/musiclibrary/utils/DataConverter.kt
+++ b/android/src/main/java/com/musiclibrary/utils/DataConverter.kt
@@ -10,16 +10,16 @@ object DataConverter {
     val map = Arguments.createMap()
     map.putString("id", track.id)
     map.putString("title", track.title)
-    track.artist?.let { map.putString("artist", it) }
-    track.artwork?.let { map.putString("artwork", it) }
-    track.album?.let { map.putString("album", it) }
+    putNullableString(map, "artist", track.artist)
+    putNullableString(map, "artwork", track.artwork)
+    putNullableString(map, "album", track.album)
     map.putDouble("duration", track.duration)
     map.putString("url", track.url)
     track.contentUri?.let { map.putString("contentUri", it) }
     map.putLong("fileSize", track.fileSize)
 
-    track.createdAt?.let { map.putDouble("createdAt", it.toDouble()) }
-    track.modifiedAt?.let { map.putDouble("modifiedAt", it.toDouble()) }
+    putNullableLong(map, "createdAt", track.createdAt)
+    putNullableLong(map, "modifiedAt", track.modifiedAt)
 
     return map
   }
@@ -29,9 +29,9 @@ object DataConverter {
     map.putString("id", album.id)
     map.putString("title", album.title)
     map.putString("artist", album.artist)
-    album.artwork?.let { map.putString("artwork", it) }
+    putNullableString(map, "artwork", album.artwork)
     map.putInt("trackCount", album.trackCount)
-    album.year?.let { map.putInt("year", it) }
+    if (album.year == null) map.putNull("year") else map.putInt("year", album.year)
 
     return map
   }
@@ -77,23 +77,39 @@ object DataConverter {
   fun trackMetadataToWritableMap(metadata: TrackMetadata): WritableMap {
     val map = Arguments.createMap()
     map.putString("id", metadata.id)
-    metadata.duration?.let { map.putDouble("duration", it) }
-    metadata.bitrate?.let { map.putLong("bitrate", it) }
-    metadata.sampleRate?.let { map.putInt("sampleRate", it) }
-    metadata.channels?.let { map.putString("channels", it) }
-    metadata.format?.let { map.putString("format", it) }
-    metadata.title?.let { map.putString("title", it) }
-    metadata.artist?.let { map.putString("artist", it) }
-    metadata.album?.let { map.putString("album", it) }
-    metadata.year?.let { map.putInt("year", it) }
-    metadata.genre?.let { map.putString("genre", it) }
-    metadata.track?.let { map.putInt("track", it) }
-    metadata.disc?.let { map.putInt("disc", it) }
-    metadata.composer?.let { map.putString("composer", it) }
-    metadata.lyricist?.let { map.putString("lyricist", it) }
-    metadata.lyrics?.let { map.putString("lyrics", it) }
-    metadata.albumArtist?.let { map.putString("albumArtist", it) }
-    metadata.comment?.let { map.putString("comment", it) }
+    putNullableDouble(map, "duration", metadata.duration)
+    putNullableLong(map, "bitrate", metadata.bitrate)
+    putNullableInt(map, "sampleRate", metadata.sampleRate)
+    putNullableString(map, "channels", metadata.channels)
+    putNullableString(map, "format", metadata.format)
+    putNullableString(map, "title", metadata.title)
+    putNullableString(map, "artist", metadata.artist)
+    putNullableString(map, "album", metadata.album)
+    putNullableInt(map, "year", metadata.year)
+    putNullableString(map, "genre", metadata.genre)
+    putNullableInt(map, "track", metadata.track)
+    putNullableInt(map, "disc", metadata.disc)
+    putNullableString(map, "composer", metadata.composer)
+    putNullableString(map, "lyricist", metadata.lyricist)
+    putNullableString(map, "lyrics", metadata.lyrics)
+    putNullableString(map, "albumArtist", metadata.albumArtist)
+    putNullableString(map, "comment", metadata.comment)
     return map
+  }
+
+  private fun putNullableString(map: WritableMap, key: String, value: String?) {
+    if (value == null) map.putNull(key) else map.putString(key, value)
+  }
+
+  private fun putNullableInt(map: WritableMap, key: String, value: Int?) {
+    if (value == null) map.putNull(key) else map.putInt(key, value)
+  }
+
+  private fun putNullableLong(map: WritableMap, key: String, value: Long?) {
+    if (value == null) map.putNull(key) else map.putDouble(key, value.toDouble())
+  }
+
+  private fun putNullableDouble(map: WritableMap, key: String, value: Double?) {
+    if (value == null) map.putNull(key) else map.putDouble(key, value)
   }
 }

--- a/android/src/main/java/com/musiclibrary/utils/ModuleUtils.kt
+++ b/android/src/main/java/com/musiclibrary/utils/ModuleUtils.kt
@@ -29,7 +29,7 @@ object ModuleUtils {
     } catch (e: SecurityException) {
       promise.reject("PERMISSION_DENIED", e.message, e)
     } catch (e: Exception) {
-      promise.reject("MODULE_ERROR", "Operation failed: ${e.message}", e)
+      promise.reject("QUERY_ERROR", "Operation failed: ${e.message}", e)
     }
   }
 
@@ -44,4 +44,4 @@ object ModuleUtils {
       ) == PackageManager.PERMISSION_GRANTED
     }
   }
-} 
+}

--- a/android/src/main/java/com/musiclibrary/utils/Pagination.kt
+++ b/android/src/main/java/com/musiclibrary/utils/Pagination.kt
@@ -1,0 +1,70 @@
+package com.musiclibrary.utils
+
+import com.facebook.react.bridge.Promise
+
+internal sealed class PaginationException(
+  val code: String,
+  message: String,
+) : IllegalArgumentException(message)
+
+internal class InvalidCursorException(cursor: String) : PaginationException(
+  code = "INVALID_CURSOR",
+  message = "Cursor must be a positive decimal ID: $cursor",
+)
+
+internal class CursorNotFoundException(cursor: String) : PaginationException(
+  code = "CURSOR_NOT_FOUND",
+  message = "Cursor is not present in the current query result: $cursor",
+)
+
+internal class InvalidPageSizeException(first: Int) : PaginationException(
+  code = "INVALID_PAGE_SIZE",
+  message = "Page size must be between 1 and 1000: $first",
+)
+
+internal fun validatePageSize(first: Int) {
+  if (first !in 1..1000) {
+    throw InvalidPageSizeException(first)
+  }
+}
+
+internal fun moveToPageStart(
+  after: String?,
+  moveToFirst: () -> Boolean,
+  currentId: () -> String,
+  moveToNext: () -> Boolean,
+): Boolean {
+  if (after == null) {
+    return moveToFirst()
+  }
+
+  if (!isValidCursor(after)) {
+    throw InvalidCursorException(after)
+  }
+
+  if (moveToFirst()) {
+    do {
+      if (currentId() == after) {
+        return moveToNext()
+      }
+    } while (moveToNext())
+  }
+
+  throw CursorNotFoundException(after)
+}
+
+private fun isValidCursor(cursor: String): Boolean {
+  val maxCursorId = "18446744073709551615"
+  return cursor.matches(Regex("[1-9][0-9]*")) &&
+    (cursor.length < maxCursorId.length ||
+      (cursor.length == maxCursorId.length && cursor <= maxCursorId))
+}
+
+internal fun Promise.rejectQueryError(error: Exception, fallbackMessage: String) {
+  if (error is PaginationException) {
+    reject(error.code, error.message, error)
+    return
+  }
+
+  reject("QUERY_ERROR", "$fallbackMessage: ${error.message}", error)
+}

--- a/android/src/main/java/com/musiclibrary/utils/Pagination.kt
+++ b/android/src/main/java/com/musiclibrary/utils/Pagination.kt
@@ -1,11 +1,9 @@
 package com.musiclibrary.utils
 
-import com.facebook.react.bridge.Promise
-
 internal sealed class PaginationException(
-  val code: String,
+  override val code: String,
   message: String,
-) : IllegalArgumentException(message)
+) : IllegalArgumentException(message), CodedQueryException
 
 internal class InvalidCursorException(cursor: String) : PaginationException(
   code = "INVALID_CURSOR",
@@ -58,13 +56,4 @@ private fun isValidCursor(cursor: String): Boolean {
   return cursor.matches(Regex("[1-9][0-9]*")) &&
     (cursor.length < maxCursorId.length ||
       (cursor.length == maxCursorId.length && cursor <= maxCursorId))
-}
-
-internal fun Promise.rejectQueryError(error: Exception, fallbackMessage: String) {
-  if (error is PaginationException) {
-    reject(error.code, error.message, error)
-    return
-  }
-
-  reject("QUERY_ERROR", "$fallbackMessage: ${error.message}", error)
 }

--- a/android/src/main/java/com/musiclibrary/utils/QueryErrors.kt
+++ b/android/src/main/java/com/musiclibrary/utils/QueryErrors.kt
@@ -1,0 +1,16 @@
+package com.musiclibrary.utils
+
+import com.facebook.react.bridge.Promise
+
+internal interface CodedQueryException {
+  val code: String
+}
+
+internal fun Promise.rejectQueryError(error: Exception, fallbackMessage: String) {
+  if (error is CodedQueryException) {
+    reject(error.code, error.message, error)
+    return
+  }
+
+  reject("QUERY_ERROR", "$fallbackMessage: ${error.message}", error)
+}

--- a/android/src/main/java/com/musiclibrary/utils/QueryErrors.kt
+++ b/android/src/main/java/com/musiclibrary/utils/QueryErrors.kt
@@ -7,6 +7,11 @@ internal interface CodedQueryException {
 }
 
 internal fun Promise.rejectQueryError(error: Exception, fallbackMessage: String) {
+  if (error is SecurityException) {
+    reject("PERMISSION_DENIED", error.message, error)
+    return
+  }
+
   if (error is CodedQueryException) {
     reject(error.code, error.message, error)
     return

--- a/android/src/test/java/com/musiclibrary/albums/AlbumSortOrderTest.kt
+++ b/android/src/test/java/com/musiclibrary/albums/AlbumSortOrderTest.kt
@@ -1,0 +1,17 @@
+package com.musiclibrary.albums
+
+import com.musiclibrary.models.SortOption
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AlbumSortOrderTest {
+  @Test
+  fun `multiple sorts preserve declared priority before id`() {
+    assertEquals(
+      "artist ASC, album DESC, _id ASC",
+      GetAlbumsQuery.buildAlbumSortOrder(
+        listOf(SortOption("artist", true), SortOption("title", false)),
+      ),
+    )
+  }
+}

--- a/android/src/test/java/com/musiclibrary/artists/ArtistSortOrderTest.kt
+++ b/android/src/test/java/com/musiclibrary/artists/ArtistSortOrderTest.kt
@@ -1,0 +1,17 @@
+package com.musiclibrary.artists
+
+import com.musiclibrary.models.SortOption
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArtistSortOrderTest {
+  @Test
+  fun `multiple sorts preserve declared priority before id`() {
+    assertEquals(
+      "number_of_albums DESC, artist ASC, _id ASC",
+      GetArtistsQuery.buildArtistSortOrder(
+        listOf(SortOption("albumCount", false), SortOption("title", true)),
+      ),
+    )
+  }
+}

--- a/android/src/test/java/com/musiclibrary/tracks/AudioMetadataExtractorTest.kt
+++ b/android/src/test/java/com/musiclibrary/tracks/AudioMetadataExtractorTest.kt
@@ -1,0 +1,30 @@
+package com.musiclibrary.tracks
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AudioMetadataExtractorTest {
+  @Test
+  fun `temporary metadata resource preserves safe display-name extension`() {
+    assertEquals(
+      ".flac",
+      AudioMetadataExtractor.fileSuffix("Track.FLAC", "audio/mpeg"),
+    )
+  }
+
+  @Test
+  fun `mime type supplies extension when display name has none`() {
+    assertEquals(
+      ".mp3",
+      AudioMetadataExtractor.fileSuffix("Track", "audio/mpeg"),
+    )
+  }
+
+  @Test
+  fun `unknown resource type receives neutral suffix`() {
+    assertEquals(
+      ".audio",
+      AudioMetadataExtractor.fileSuffix(null, null),
+    )
+  }
+}

--- a/android/src/test/java/com/musiclibrary/tracks/TrackDirectoryFilterTest.kt
+++ b/android/src/test/java/com/musiclibrary/tracks/TrackDirectoryFilterTest.kt
@@ -1,0 +1,36 @@
+package com.musiclibrary.tracks
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TrackDirectoryFilterTest {
+  @Test
+  fun `primary tree maps to primary MediaStore volume and relative path`() {
+    assertEquals(
+      ExternalStorageDirectory("external_primary", "Music/Live/%"),
+      TrackDirectoryFilter.parseExternalStorageDocumentId("primary:Music/Live"),
+    )
+  }
+
+  @Test
+  fun `removable tree preserves normalized volume name`() {
+    assertEquals(
+      ExternalStorageDirectory("1234-abcd", "Audio/%"),
+      TrackDirectoryFilter.parseExternalStorageDocumentId("1234-ABCD:Audio"),
+    )
+  }
+
+  @Test
+  fun `volume root covers every relative path`() {
+    assertEquals(
+      ExternalStorageDirectory("external_primary", null),
+      TrackDirectoryFilter.parseExternalStorageDocumentId("primary:"),
+    )
+  }
+
+  @Test
+  fun `missing volume is rejected`() {
+    assertNull(TrackDirectoryFilter.parseExternalStorageDocumentId(":"))
+  }
+}

--- a/android/src/test/java/com/musiclibrary/tracks/TrackSortOrderTest.kt
+++ b/android/src/test/java/com/musiclibrary/tracks/TrackSortOrderTest.kt
@@ -6,6 +6,25 @@ import org.junit.Test
 
 class TrackSortOrderTest {
   @Test
+  fun `legacy file URL is preserved when MediaStore exposes a path`() {
+    assertEquals(
+      "file:///storage/emulated/0/Music/track.mp3",
+      TrackQuery.selectTrackUrl(
+        "content://media/external/audio/media/1",
+        "/storage/emulated/0/Music/track.mp3",
+      ),
+    )
+  }
+
+  @Test
+  fun `content URI is playable fallback when legacy path is absent`() {
+    assertEquals(
+      "content://media/external/audio/media/1",
+      TrackQuery.selectTrackUrl("content://media/external/audio/media/1", null),
+    )
+  }
+
+  @Test
   fun `default sort is title ascending with stable id tie breaker`() {
     assertEquals(
       "title ASC, _id ASC",

--- a/android/src/test/java/com/musiclibrary/tracks/TrackSortOrderTest.kt
+++ b/android/src/test/java/com/musiclibrary/tracks/TrackSortOrderTest.kt
@@ -1,0 +1,26 @@
+package com.musiclibrary.tracks
+
+import com.musiclibrary.models.SortOption
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TrackSortOrderTest {
+  @Test
+  fun `default sort is title ascending with stable id tie breaker`() {
+    assertEquals(
+      "title ASC, _id ASC",
+      TrackQuery.buildTrackSortOrder(TrackSortPolicy.Options, emptyList()),
+    )
+  }
+
+  @Test
+  fun `multiple sorts preserve declared priority before id`() {
+    assertEquals(
+      "artist ASC, title DESC, _id ASC",
+      TrackQuery.buildTrackSortOrder(
+        TrackSortPolicy.Options,
+        listOf(SortOption("artist", true), SortOption("title", false)),
+      ),
+    )
+  }
+}

--- a/android/src/test/java/com/musiclibrary/utils/CursorPageReaderTest.kt
+++ b/android/src/test/java/com/musiclibrary/utils/CursorPageReaderTest.kt
@@ -1,0 +1,79 @@
+package com.musiclibrary.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CursorPageReaderTest {
+  @Test
+  fun skipsInvalidRowsAndContinuesReading() {
+    val rows = listOf<String?>(null, "album-1", null, "album-2")
+    var position = 0
+
+    val page = readCursorPage(
+      canReadFirst = true,
+      maxItems = 2,
+      readItem = { rows[position] },
+      moveToNext = {
+        position++
+        position < rows.size
+      },
+      isAfterLast = { position >= rows.size },
+    )
+
+    assertEquals(listOf("album-1", "album-2"), page.items)
+    assertFalse(page.hasNextPage)
+    assertEquals(rows.size, position)
+  }
+
+  @Test
+  fun advancesAfterConversionFailure() {
+    val rows = listOf("broken", "artist-1")
+    var position = 0
+    var reads = 0
+
+    val page = readCursorPage(
+      canReadFirst = true,
+      maxItems = 1,
+      readItem = {
+        reads++
+        if (rows[position] == "broken") {
+          throw IllegalStateException("Cannot convert row")
+        }
+        rows[position]
+      },
+      moveToNext = {
+        position++
+        position < rows.size
+      },
+      isAfterLast = { position >= rows.size },
+    )
+
+    assertEquals(listOf("artist-1"), page.items)
+    assertEquals(2, reads)
+    assertEquals(rows.size, position)
+    assertFalse(page.hasNextPage)
+  }
+
+  @Test
+  fun reportsAnotherPageAfterFillingTheCurrentPage() {
+    val rows = listOf("artist-1", "artist-2")
+    var position = 0
+
+    val page = readCursorPage(
+      canReadFirst = true,
+      maxItems = 1,
+      readItem = { rows[position] },
+      moveToNext = {
+        position++
+        position < rows.size
+      },
+      isAfterLast = { position >= rows.size },
+    )
+
+    assertEquals(listOf("artist-1"), page.items)
+    assertEquals(1, position)
+    assertTrue(page.hasNextPage)
+  }
+}

--- a/android/src/test/java/com/musiclibrary/utils/PaginationTest.kt
+++ b/android/src/test/java/com/musiclibrary/utils/PaginationTest.kt
@@ -1,0 +1,84 @@
+package com.musiclibrary.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PaginationTest {
+  @Test
+  fun `missing cursor starts at the first item`() {
+    val ids = listOf("1", "2")
+    var index = -1
+
+    val canRead = moveToPageStart(
+      after = null,
+      moveToFirst = { index = 0; ids.isNotEmpty() },
+      currentId = { ids[index] },
+      moveToNext = { index++; index < ids.size },
+    )
+
+    assertTrue(canRead)
+    assertTrue(index == 0)
+  }
+
+  @Test(expected = InvalidCursorException::class)
+  fun `malformed cursor is rejected`() {
+    moveToPageStart(
+      after = "not-an-id",
+      moveToFirst = { false },
+      currentId = { error("not called") },
+      moveToNext = { false },
+    )
+  }
+
+  @Test(expected = InvalidCursorException::class)
+  fun `cursor above unsigned 64 bit range is rejected`() {
+    moveToPageStart(
+      after = "18446744073709551616",
+      moveToFirst = { false },
+      currentId = { error("not called") },
+      moveToNext = { false },
+    )
+  }
+
+  @Test(expected = CursorNotFoundException::class)
+  fun `unknown cursor is rejected`() {
+    locate(listOf("1", "2"), after = "3")
+  }
+
+  @Test
+  fun `final cursor produces a normal empty page`() {
+    assertFalse(locate(listOf("1", "2"), after = "2"))
+  }
+
+  @Test
+  fun `empty result without a cursor is normal`() {
+    assertFalse(locate(emptyList(), after = null))
+  }
+
+  @Test(expected = InvalidPageSizeException::class)
+  fun `zero page size is rejected`() {
+    validatePageSize(0)
+  }
+
+  @Test(expected = InvalidPageSizeException::class)
+  fun `page size above the cap is rejected`() {
+    validatePageSize(1001)
+  }
+
+  @Test
+  fun `page size boundaries are accepted`() {
+    validatePageSize(1)
+    validatePageSize(1000)
+  }
+
+  private fun locate(ids: List<String>, after: String?): Boolean {
+    var index = -1
+    return moveToPageStart(
+      after = after,
+      moveToFirst = { index = 0; ids.isNotEmpty() },
+      currentId = { ids[index] },
+      moveToNext = { index++; index < ids.size },
+    )
+  }
+}

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -199,8 +199,8 @@ const albums = await getAlbumsByArtistAsync('artist-id-123');
 
 ```typescript
 interface TrackOptions {
-  after?: string; // Cursor for pagination
-  first?: number; // Max items to return (default: 20)
+  after?: string; // Previous page's entity-ID cursor
+  first?: number; // 1–1000 items (default: 20)
   sortBy?: SortByValue<TrackSortByKey> | SortByValue<TrackSortByKey>[];
   directory?: string; // Directory path to search
 }
@@ -210,8 +210,8 @@ interface TrackOptions {
 
 ```typescript
 interface AlbumOptions {
-  after?: string; // Cursor for pagination
-  first?: number; // Max items to return (default: 20)
+  after?: string; // Previous page's entity-ID cursor
+  first?: number; // 1–1000 items (default: 20)
   sortBy?: SortByValue<AlbumSortByKey> | SortByValue<AlbumSortByKey>[];
 }
 ```
@@ -220,11 +220,17 @@ interface AlbumOptions {
 
 ```typescript
 interface ArtistOptions {
-  after?: string; // Cursor for pagination
-  first?: number; // Max items to return (default: 20)
+  after?: string; // Previous page's entity-ID cursor
+  first?: number; // 1–1000 items (default: 20)
   sortBy?: SortByValue<ArtistSortByKey> | SortByValue<ArtistSortByKey>[];
 }
 ```
+
+The cursor is the ID of the last entity returned by the previous page and must
+be reused with the same entity, filters, and normalized sort. A malformed
+cursor rejects with `INVALID_CURSOR`. A valid ID absent from the current query
+rejects with `CURSOR_NOT_FOUND`. A cursor at the final entity returns an empty
+terminal page with no `endCursor`.
 
 ### `Track`
 
@@ -237,8 +243,8 @@ interface Track {
   album: string; // Album name
   duration: number; // Duration in seconds
   url: string; // File URL or path
-  createdAt: number; // Date added (Unix timestamp)
-  modifiedAt: number; // Date modified (Unix timestamp)
+  createdAt?: number | null; // Date added (Unix seconds)
+  modifiedAt?: number | null; // Resource modification time; null on iOS
   fileSize: number; // File size in bytes
 }
 ```
@@ -298,6 +304,11 @@ interface TrackMetadata {
 
 ## Sorting Options
 
+The default sort is title ascending. A bare key is descending. Multiple sort
+descriptors are evaluated in declaration order, then the entity ID is used as
+an ascending tie-breaker. Missing string or numeric values sort before populated
+values in ascending order where both platforms expose the field.
+
 ### Track Sorting Keys
 
 - `'default'` - Default sorting (title)
@@ -306,7 +317,7 @@ interface TrackMetadata {
 - `'album'` - Sort by album name
 - `'duration'` - Sort by duration
 - `'createdAt'` - Sort by creation date
-- `'modifiedAt'` - Sort by modification date
+- `'modifiedAt'` - Sort by resource modification date (Android; unavailable values on iOS tie and fall back to ID)
 - `'fileSize'` - Sort by file size
 
 ### Album Sorting Keys

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -202,7 +202,7 @@ interface TrackOptions {
   after?: string; // Previous page's entity-ID cursor
   first?: number; // 1–1000 items (default: 20)
   sortBy?: SortByValue<TrackSortByKey> | SortByValue<TrackSortByKey>[];
-  directory?: string; // Directory path to search
+  directory?: string; // Legacy path or supported Android SAF tree URI
 }
 ```
 
@@ -242,12 +242,26 @@ interface Track {
   artwork?: string; // Artwork file URI (may be undefined)
   album: string; // Album name
   duration: number; // Duration in seconds
-  url: string; // File URL or path
+  url: string; // Playable resource URI
+  contentUri?: string | null; // Canonical Android MediaStore URI
   createdAt?: number | null; // Date added (Unix seconds)
   modifiedAt?: number | null; // Resource modification time; null on iOS
   fileSize: number; // File size in bytes
 }
 ```
+
+#### Android Track resource compatibility
+
+Prefer `contentUri` for Android playback or resource access. For compatibility,
+`url` remains a `file://` URI when MediaStore exposes a legacy path and falls
+back to `contentUri` when it does not. Embedded Track Metadata is read through
+`ContentResolver` and a temporary file adapter for the file-based tag parser.
+
+Absolute `directory` paths retain the legacy `DATA` filter. On Android 10 and
+newer, Storage Access Framework tree URIs from
+`com.android.externalstorage.documents` are mapped to MediaStore volume and
+relative-path filters, including mounted removable volumes. Other providers and
+SAF tree filtering before Android 10 reject with `UNSUPPORTED_DIRECTORY_URI`.
 
 ### `Album`
 

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -238,14 +238,14 @@ terminal page with no `endCursor`.
 interface Track {
   id: string;
   title: string; // Track title
-  artist: string; // Artist name
-  artwork?: string; // Artwork file URI (may be undefined)
-  album: string; // Album name
+  artist: string | null; // Artist name, or null
+  artwork: string | null; // Artwork reference, or null
+  album: string | null; // Album name, or null
   duration: number; // Duration in seconds
   url: string; // Playable resource URI
   contentUri?: string | null; // Canonical Android MediaStore URI
-  createdAt?: number | null; // Date added (Unix seconds)
-  modifiedAt?: number | null; // Resource modification time; null on iOS
+  createdAt: number | null; // Date added (Unix seconds), or null
+  modifiedAt: number | null; // Resource modification time; null on iOS
   fileSize: number; // File size in bytes
 }
 ```
@@ -270,9 +270,9 @@ interface Album {
   id: string;
   title: string; // Album name
   artist: string; // Primary artist
-  artwork?: string; // Album artwork URI
+  artwork: string | null; // Album artwork reference, or null
   trackCount: number; // Number of tracks
-  year?: number; // Release year
+  year: number | null; // Release year, or null
 }
 ```
 
@@ -294,27 +294,48 @@ interface TrackMetadata {
   id: string; // Track ID
 
   // Audio header
-  duration: number; // Duration in seconds
-  bitrate: number; // Bitrate in kbps
-  sampleRate: number; // Sample rate in Hz
-  channels: string; // Number of channels (e.g. "2")
-  format: string; // Audio format
+  duration: number | null; // Duration in seconds, or null
+  bitrate: number | null; // Bitrate in kbps, or null
+  sampleRate: number | null; // Sample rate in Hz, or null
+  channels: string | null; // Number of channels, or null
+  format: string | null; // Audio format, or null
 
   // Tag info
-  title: string; // Track title
-  artist: string; // Artist name
-  album: string; // Album name
-  year: number; // Release year
-  genre: string; // Music genre
-  track: number; // Track number
-  disc: number; // Disc number
-  composer: string; // Composer
-  lyricist: string; // Lyricist
-  lyrics: string; // Lyrics content
-  albumArtist: string; // Album artist
-  comment: string; // Comment
+  title: string | null; // Track title, or null
+  artist: string | null; // Artist name, or null
+  album: string | null; // Album name, or null
+  year: number | null; // Release year, or null
+  genre: string | null; // Music genre, or null
+  track: number | null; // Track number, or null
+  disc: number | null; // Disc number, or null
+  composer: string | null; // Composer, or null
+  lyricist: string | null; // Lyricist, or null
+  lyrics: string | null; // Lyrics content, or null
+  albumArtist: string | null; // Album artist, or null
+  comment: string | null; // Comment, or null
 }
 ```
+
+## Result and Error Contract
+
+Nullable entity and Track Metadata fields are always present and contain
+`null` when unavailable. Structural optional fields are omitted:
+`contentUri` is Android-only, while terminal pagination results omit
+`endCursor`. If Embedded Metadata is absent or unreadable,
+`getTrackMetadataAsync` still resolves with available Library Metadata and
+`null` for missing values.
+
+Native failures reject with a `MusicLibraryError` whose `code` is one of:
+
+| Code                        | Meaning                                                   |
+| --------------------------- | --------------------------------------------------------- |
+| `PERMISSION_DENIED`         | Local Music Library access is not authorized              |
+| `TRACK_NOT_FOUND`           | The requested Track no longer exists                      |
+| `QUERY_ERROR`               | The native query or resource read failed                  |
+| `INVALID_CURSOR`            | `after` is not a valid entity-ID cursor                   |
+| `CURSOR_NOT_FOUND`          | The cursor is valid but absent from the current query     |
+| `INVALID_PAGE_SIZE`         | `first` is outside `1`–`1000`                             |
+| `UNSUPPORTED_DIRECTORY_URI` | Android cannot safely map the directory URI to MediaStore |
 
 ## Sorting Options
 

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -32,6 +32,23 @@ const nextPage = firstPage.hasNextPage
   : undefined;
 ```
 
+## Load a complete result
+
+Use the high-level helpers when the workflow needs the complete current list.
+The paginated methods remain available for incremental screens.
+
+```ts
+import {
+  getAllTracksAsync,
+  getAllAlbumsAsync,
+  getAllArtistsAsync,
+} from '@nodefinity/react-native-music-library';
+
+const tracks = await getAllTracksAsync({ first: 100 });
+const albums = await getAllAlbumsAsync({ first: 100 });
+const artists = await getAllArtistsAsync({ first: 100 });
+```
+
 ## Read audio metadata and lyrics
 
 Load detailed Track Metadata when a user opens a track. The returned values

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -95,7 +95,7 @@ const loadTracks = async () => {
       console.log(
         `Duration: ${Math.floor(track.duration / 60)}:${track.duration % 60}`
       );
-      console.log(`File: ${track.url}`);
+      console.log(`Resource: ${track.contentUri ?? track.url}`);
     });
   } catch (error) {
     console.error('Failed to load tracks:', error);

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/api.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/api.md
@@ -237,14 +237,14 @@ interface ArtistOptions {
 interface Track {
   id: string;
   title: string; // 曲目标题
-  artist: string; // 艺术家名称
-  artwork?: string; // 封面文件 URI（可能为空）
-  album: string; // 专辑名称
+  artist: string | null; // 艺术家名称，缺失时为 null
+  artwork: string | null; // 封面引用，缺失时为 null
+  album: string | null; // 专辑名称，缺失时为 null
   duration: number; // 时长（秒）
   url: string; // 可播放的资源 URI
   contentUri?: string | null; // Android MediaStore 规范 URI
-  createdAt?: number | null; // 添加日期（Unix 秒）
-  modifiedAt?: number | null; // 资源修改时间；iOS 上为 null
+  createdAt: number | null; // 添加日期（Unix 秒），缺失时为 null
+  modifiedAt: number | null; // 资源修改时间；iOS 上为 null
   fileSize: number; // 文件大小（字节）
 }
 ```
@@ -268,9 +268,9 @@ interface Album {
   id: string;
   title: string; // 专辑名称
   artist: string; // 主要艺术家
-  artwork?: string; // 专辑封面 URI
+  artwork: string | null; // 专辑封面引用，缺失时为 null
   trackCount: number; // 曲目数量
-  year?: number; // 发行年份
+  year: number | null; // 发行年份，缺失时为 null
 }
 ```
 
@@ -292,27 +292,46 @@ interface TrackMetadata {
   id: string; // 曲目 ID
 
   // 音频头信息
-  duration: number; // 时长（秒）
-  bitrate: number; // 比特率（kbps）
-  sampleRate: number; // 采样率（Hz）
-  channels: string; // 声道数（如 "2"）
-  format: string; // 音频格式
+  duration: number | null; // 时长（秒），缺失时为 null
+  bitrate: number | null; // 比特率（kbps），缺失时为 null
+  sampleRate: number | null; // 采样率（Hz），缺失时为 null
+  channels: string | null; // 声道数，缺失时为 null
+  format: string | null; // 音频格式，缺失时为 null
 
   // 标签信息
-  title: string; // 曲目标题
-  artist: string; // 艺术家名称
-  album: string; // 专辑名称
-  year: number; // 发行年份
-  genre: string; // 音乐流派
-  track: number; // 曲目编号
-  disc: number; // 碟片编号
-  composer: string; // 作曲家
-  lyricist: string; // 作词家
-  lyrics: string; // 歌词内容
-  albumArtist: string; // 专辑艺术家
-  comment: string; // 注释
+  title: string | null; // 曲目标题，缺失时为 null
+  artist: string | null; // 艺术家名称，缺失时为 null
+  album: string | null; // 专辑名称，缺失时为 null
+  year: number | null; // 发行年份，缺失时为 null
+  genre: string | null; // 音乐流派，缺失时为 null
+  track: number | null; // 曲目编号，缺失时为 null
+  disc: number | null; // 碟片编号，缺失时为 null
+  composer: string | null; // 作曲家，缺失时为 null
+  lyricist: string | null; // 作词家，缺失时为 null
+  lyrics: string | null; // 歌词内容，缺失时为 null
+  albumArtist: string | null; // 专辑艺术家，缺失时为 null
+  comment: string | null; // 注释，缺失时为 null
 }
 ```
+
+## 返回值与错误契约
+
+实体和曲目元数据中的可空字段始终存在；无可用值时返回 `null`。结构性的可选
+字段则会省略：`contentUri` 仅 Android 返回，分页终止页不含 `endCursor`。
+内嵌元数据不存在或无法读取时，`getTrackMetadataAsync` 仍会返回已有的音乐库
+元数据，其余字段为 `null`。
+
+原生失败会拒绝 Promise，并返回带稳定 `code` 的 `MusicLibraryError`：
+
+| Code                        | 含义                                         |
+| --------------------------- | -------------------------------------------- |
+| `PERMISSION_DENIED`         | 未获得本地音乐库访问权限                     |
+| `TRACK_NOT_FOUND`           | 请求的曲目已不存在                           |
+| `QUERY_ERROR`               | 原生查询或资源读取失败                       |
+| `INVALID_CURSOR`            | `after` 不是合法的实体 ID 游标               |
+| `CURSOR_NOT_FOUND`          | 游标格式合法，但不在当前查询结果中           |
+| `INVALID_PAGE_SIZE`         | `first` 不在 `1`–`1000` 范围内               |
+| `UNSUPPORTED_DIRECTORY_URI` | Android 无法将目录 URI 安全映射到 MediaStore |
 
 ## 排序选项
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/api.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/api.md
@@ -199,8 +199,8 @@ const albums = await getAlbumsByArtistAsync('artist-id-123');
 
 ```typescript
 interface TrackOptions {
-  after?: string; // 分页游标
-  first?: number; // 最大返回项目数（默认：20）
+  after?: string; // 上一页返回的实体 ID 游标
+  first?: number; // 返回 1–1000 项（默认：20）
   sortBy?: SortByValue<TrackSortByKey> | SortByValue<TrackSortByKey>[];
   directory?: string; // 搜索目录路径
 }
@@ -210,8 +210,8 @@ interface TrackOptions {
 
 ```typescript
 interface AlbumOptions {
-  after?: string; // 分页游标
-  first?: number; // 最大返回项目数（默认：20）
+  after?: string; // 上一页返回的实体 ID 游标
+  first?: number; // 返回 1–1000 项（默认：20）
   sortBy?: SortByValue<AlbumSortByKey> | SortByValue<AlbumSortByKey>[];
 }
 ```
@@ -220,11 +220,16 @@ interface AlbumOptions {
 
 ```typescript
 interface ArtistOptions {
-  after?: string; // 分页游标
-  first?: number; // 最大返回项目数（默认：20）
+  after?: string; // 上一页返回的实体 ID 游标
+  first?: number; // 返回 1–1000 项（默认：20）
   sortBy?: SortByValue<ArtistSortByKey> | SortByValue<ArtistSortByKey>[];
 }
 ```
+
+游标是上一页最后一个实体的 ID，必须与生成它时的实体类型、筛选条件和
+规范化排序一起复用。格式错误的游标会以 `INVALID_CURSOR` 拒绝；格式正确但
+不在当前查询结果中的 ID 会以 `CURSOR_NOT_FOUND` 拒绝。游标指向最后一个实体
+时，返回不含 `endCursor` 的正常空白终止页。
 
 ### `Track`
 
@@ -237,8 +242,8 @@ interface Track {
   album: string; // 专辑名称
   duration: number; // 时长（秒）
   url: string; // 文件 URL 或路径
-  createdAt: number; // 添加日期（Unix 时间戳）
-  modifiedAt: number; // 修改日期（Unix 时间戳）
+  createdAt?: number | null; // 添加日期（Unix 秒）
+  modifiedAt?: number | null; // 资源修改时间；iOS 上为 null
   fileSize: number; // 文件大小（字节）
 }
 ```
@@ -298,6 +303,10 @@ interface TrackMetadata {
 
 ## 排序选项
 
+默认按标题升序。单独传入排序键时表示降序。多个排序条件按声明顺序进行
+词典序比较，最后以实体 ID 升序打破平局。两个平台都提供对应字段时，缺失的
+字符串或数值在升序中排在已有值之前。
+
 ### 曲目排序键
 
 - `'default'` - 默认排序（标题）
@@ -306,7 +315,7 @@ interface TrackMetadata {
 - `'album'` - 按专辑名称排序
 - `'duration'` - 按时长排序
 - `'createdAt'` - 按创建日期排序
-- `'modifiedAt'` - 按修改日期排序
+- `'modifiedAt'` - 按资源修改日期排序（Android；iOS 缺失值相等并回退到 ID）
 - `'fileSize'` - 按文件大小排序
 
 ### 专辑排序键

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/api.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/api.md
@@ -202,7 +202,7 @@ interface TrackOptions {
   after?: string; // 上一页返回的实体 ID 游标
   first?: number; // 返回 1–1000 项（默认：20）
   sortBy?: SortByValue<TrackSortByKey> | SortByValue<TrackSortByKey>[];
-  directory?: string; // 搜索目录路径
+  directory?: string; // 旧路径或受支持的 Android SAF 树 URI
 }
 ```
 
@@ -241,12 +241,25 @@ interface Track {
   artwork?: string; // 封面文件 URI（可能为空）
   album: string; // 专辑名称
   duration: number; // 时长（秒）
-  url: string; // 文件 URL 或路径
+  url: string; // 可播放的资源 URI
+  contentUri?: string | null; // Android MediaStore 规范 URI
   createdAt?: number | null; // 添加日期（Unix 秒）
   modifiedAt?: number | null; // 资源修改时间；iOS 上为 null
   fileSize: number; // 文件大小（字节）
 }
 ```
+
+#### Android 曲目资源兼容策略
+
+Android 播放或资源访问应优先使用 `contentUri`。为保持兼容，MediaStore 能提供
+旧文件路径时，`url` 仍是 `file://` URI；不能提供时，`url` 回退为同一个
+`contentUri`。内嵌曲目元数据通过 `ContentResolver` 读取，并用临时文件适配
+只接受文件的标签解析器。
+
+绝对 `directory` 路径保留原有的 `DATA` 筛选。Android 10 及以上支持来自
+`com.android.externalstorage.documents` 的 SAF 树 URI，并按 MediaStore 卷和
+相对路径筛选，包括已挂载的可移动存储。其他 provider，或 Android 10 以前的
+SAF 树筛选，会以 `UNSUPPORTED_DIRECTORY_URI` 拒绝。
 
 ### `Album`
 

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/examples.md
@@ -30,6 +30,22 @@ const nextPage = firstPage.hasNextPage
   : undefined;
 ```
 
+## 加载完整结果
+
+当业务需要当前完整列表时，使用高层 helper；增量加载页面仍可继续使用分页方法。
+
+```ts
+import {
+  getAllTracksAsync,
+  getAllAlbumsAsync,
+  getAllArtistsAsync,
+} from '@nodefinity/react-native-music-library';
+
+const tracks = await getAllTracksAsync({ first: 100 });
+const albums = await getAllAlbumsAsync({ first: 100 });
+const artists = await getAllArtistsAsync({ first: 100 });
+```
+
 ## 读取音频元数据和歌词
 
 当用户打开某个曲目时再加载详细的曲目元数据。返回值取决于平台和曲目本身能够提供的元数据。

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current/getting-started.md
@@ -36,7 +36,7 @@ import { request, PERMISSIONS, RESULTS } from 'react-native-permissions';
 
 const requestMusicPermission = async () => {
   const result = await request(PERMISSIONS.ANDROID.READ_MEDIA_AUDIO);
-  
+
   if (result === RESULTS.GRANTED) {
     console.log('音乐权限已授予');
   } else {
@@ -75,11 +75,11 @@ const requestMusicPermission = async () => {
 ### 导入库
 
 ```js
-import { 
-  getTracksAsync, 
-  getAlbumsAsync, 
+import {
+  getTracksAsync,
+  getAlbumsAsync,
   getArtistsAsync,
-  getTrackMetadataAsync 
+  getTrackMetadataAsync,
 } from '@nodefinity/react-native-music-library';
 ```
 
@@ -89,11 +89,13 @@ import {
 const loadTracks = async () => {
   try {
     const result = await getTracksAsync();
-    
-    result.items.forEach(track => {
+
+    result.items.forEach((track) => {
       console.log(`${track.title} - ${track.artist}`);
-      console.log(`时长: ${Math.floor(track.duration / 60)}:${track.duration % 60}`);
-      console.log(`文件: ${track.url}`);
+      console.log(
+        `时长: ${Math.floor(track.duration / 60)}:${track.duration % 60}`
+      );
+      console.log(`资源: ${track.contentUri ?? track.url}`);
     });
   } catch (error) {
     console.error('加载曲目失败:', error);
@@ -108,10 +110,10 @@ const loadAlbums = async () => {
   try {
     const result = await getAlbumsAsync({
       sortBy: ['title', true], // 按标题升序排序
-      first: 50
+      first: 50,
     });
-    
-    result.items.forEach(album => {
+
+    result.items.forEach((album) => {
       console.log(`${album.title} - ${album.artist}`);
       console.log(`曲目数: ${album.trackCount}`);
     });
@@ -127,10 +129,10 @@ const loadAlbums = async () => {
 const loadArtists = async () => {
   try {
     const result = await getArtistsAsync({
-      sortBy: 'title' // 按名称排序
+      sortBy: 'title', // 按名称排序
     });
-    
-    result.items.forEach(artist => {
+
+    result.items.forEach((artist) => {
       console.log(`${artist.title}`);
       console.log(`专辑数: ${artist.albumCount}, 曲目数: ${artist.trackCount}`);
     });

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -32,7 +32,7 @@ PODS:
   - hermes-engine (0.79.2):
     - hermes-engine/Pre-built (= 0.79.2)
   - hermes-engine/Pre-built (0.79.2)
-  - MusicLibrary (0.10.1):
+  - MusicLibrary (0.10.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2179,7 +2179,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
-  MusicLibrary: 7cde7f3ff04c6fc2134ceed501918516aa323481
+  MusicLibrary: d63479edcd5069533b4a0a49cd779521c58579e7
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 83ffb90c23ee5cea353bd32008a7bca100908f8c
   RCTRequired: eb7c0aba998009f47a540bec9e9d69a54f68136e

--- a/example/src/contexts/PlayerContext.tsx
+++ b/example/src/contexts/PlayerContext.tsx
@@ -6,6 +6,7 @@ import { AudioPro } from 'react-native-audio-pro';
 export function toAudioProTrack(track: Track): AudioProTrack {
   return {
     ...track,
+    url: track.contentUri ?? track.url,
     artwork: track.artwork ?? require('../assets/default_artwork.png'),
     artist: track.artist ?? '',
     album: track.album ?? '',

--- a/example/src/pages/AlbumListScreen.tsx
+++ b/example/src/pages/AlbumListScreen.tsx
@@ -9,11 +9,8 @@ import {
   Alert,
   Button,
 } from 'react-native';
-import { getAlbumsAsync } from '@nodefinity/react-native-music-library';
-import type {
-  Album,
-  AlbumOptions,
-} from '@nodefinity/react-native-music-library';
+import { getAllAlbumsAsync } from '@nodefinity/react-native-music-library';
+import type { Album } from '@nodefinity/react-native-music-library';
 import { usePermission } from '../hooks/usePermission';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -26,7 +23,7 @@ export default function AlbumListScreen({ navigation }: Props) {
   const [loading, setLoading] = useState(false);
   const { permissionStatus, requestPermissions } = usePermission();
 
-  const getAllAlbums = async () => {
+  const handleGetAllAlbums = async () => {
     try {
       if (!permissionStatus?.granted) {
         const result = await requestPermissions();
@@ -41,7 +38,10 @@ export default function AlbumListScreen({ navigation }: Props) {
 
       setLoading(true);
       const startTime = Date.now();
-      const results = await loadAllAlbums();
+      const results = await getAllAlbumsAsync({
+        first: 100,
+        sortBy: ['title', true],
+      });
       const endTime = Date.now();
 
       setAlbums(results);
@@ -55,27 +55,6 @@ export default function AlbumListScreen({ navigation }: Props) {
     } finally {
       setLoading(false);
     }
-  };
-
-  const loadAllAlbums = async (options: AlbumOptions = {}) => {
-    let allAlbums: Album[] = [];
-    let hasMore = true;
-    let cursor;
-
-    while (hasMore) {
-      const result = await getAlbumsAsync({
-        first: 100,
-        ...options,
-        after: cursor,
-        sortBy: ['title', true],
-      });
-
-      allAlbums = [...allAlbums, ...result.items];
-      hasMore = result.hasNextPage;
-      cursor = result.endCursor;
-    }
-
-    return allAlbums;
   };
 
   const handleAlbumPress = async (album: Album) => {
@@ -127,7 +106,7 @@ export default function AlbumListScreen({ navigation }: Props) {
       <View style={styles.buttonContainer}>
         <Button
           title={`${loading ? 'loading...' : ''} get all albums`}
-          onPress={getAllAlbums}
+          onPress={handleGetAllAlbums}
           disabled={loading}
         />
       </View>

--- a/example/src/pages/ArtistListScreen.tsx
+++ b/example/src/pages/ArtistListScreen.tsx
@@ -8,11 +8,8 @@ import {
   Alert,
   Button,
 } from 'react-native';
-import { getArtistsAsync } from '@nodefinity/react-native-music-library';
-import type {
-  Artist,
-  ArtistOptions,
-} from '@nodefinity/react-native-music-library';
+import { getAllArtistsAsync } from '@nodefinity/react-native-music-library';
+import type { Artist } from '@nodefinity/react-native-music-library';
 import { usePermission } from '../hooks/usePermission';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -25,7 +22,7 @@ export default function ArtistListScreen({ navigation }: Props) {
   const [loading, setLoading] = useState(false);
   const { permissionStatus, requestPermissions } = usePermission();
 
-  const getAllArtists = async () => {
+  const handleGetAllArtists = async () => {
     try {
       if (!permissionStatus?.granted) {
         const result = await requestPermissions();
@@ -40,7 +37,10 @@ export default function ArtistListScreen({ navigation }: Props) {
 
       setLoading(true);
       const startTime = Date.now();
-      const results = await loadAllArtists();
+      const results = await getAllArtistsAsync({
+        first: 100,
+        sortBy: ['title', true],
+      });
       const endTime = Date.now();
 
       setArtists(results);
@@ -54,27 +54,6 @@ export default function ArtistListScreen({ navigation }: Props) {
     } finally {
       setLoading(false);
     }
-  };
-
-  const loadAllArtists = async (options: ArtistOptions = {}) => {
-    let allArtists: Artist[] = [];
-    let hasMore = true;
-    let cursor;
-
-    while (hasMore) {
-      const result = await getArtistsAsync({
-        first: 100,
-        ...options,
-        after: cursor,
-        sortBy: ['title', true],
-      });
-
-      allArtists = [...allArtists, ...result.items];
-      hasMore = result.hasNextPage;
-      cursor = result.endCursor;
-    }
-
-    return allArtists;
   };
 
   const handleArtistPress = async (artist: Artist) => {
@@ -118,7 +97,7 @@ export default function ArtistListScreen({ navigation }: Props) {
       <View style={styles.buttonContainer}>
         <Button
           title={`${loading ? 'loading...' : ''} get all artists`}
-          onPress={getAllArtists}
+          onPress={handleGetAllArtists}
           disabled={loading}
         />
       </View>

--- a/example/src/pages/TrackListScreen.tsx
+++ b/example/src/pages/TrackListScreen.tsx
@@ -1,10 +1,7 @@
 import { Alert, Button, View, FlatList, Text, StyleSheet } from 'react-native';
-import { getTracksAsync } from '@nodefinity/react-native-music-library';
+import { getAllTracksAsync } from '@nodefinity/react-native-music-library';
 import { useState } from 'react';
-import type {
-  TrackOptions,
-  Track,
-} from '@nodefinity/react-native-music-library';
+import type { Track } from '@nodefinity/react-native-music-library';
 import { usePermission } from '../hooks/usePermission';
 import { pickDirectory } from '@react-native-documents/picker';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -22,7 +19,7 @@ export default function TrackListScreen({ navigation }: Props) {
   const { permissionStatus, requestPermissions } = usePermission();
   const { setPlaylist } = usePlayer();
 
-  const getAllTracks = async () => {
+  const handleGetAllTracks = async () => {
     try {
       if (!permissionStatus?.granted) {
         const result = await requestPermissions();
@@ -37,7 +34,10 @@ export default function TrackListScreen({ navigation }: Props) {
 
       setLoading(true);
       const startTime = Date.now();
-      const results = await loadAllTracks();
+      const results = await getAllTracksAsync({
+        first: 100,
+        sortBy: ['title', true],
+      });
       const endTime = Date.now();
 
       setTracks(results);
@@ -53,28 +53,6 @@ export default function TrackListScreen({ navigation }: Props) {
     }
   };
 
-  const loadAllTracks = async (options: TrackOptions = {}) => {
-    let allTracks: Track[] = [];
-    let hasMore = true;
-    let cursor;
-
-    while (hasMore) {
-      const result = await getTracksAsync({
-        first: 100,
-        ...options,
-        after: cursor,
-        sortBy: ['title', true],
-      });
-
-      console.log('getTracksAsync result:', JSON.stringify(result, null, 2));
-      allTracks = [...allTracks, ...result.items];
-      hasMore = result.hasNextPage;
-      cursor = result.endCursor;
-    }
-
-    return allTracks;
-  };
-
   const getTracksFromPickedDirectory = async () => {
     try {
       const { uri } = await pickDirectory({
@@ -83,7 +61,11 @@ export default function TrackListScreen({ navigation }: Props) {
 
       if (!uri) return;
 
-      const results = await loadAllTracks({ directory: uri });
+      const results = await getAllTracksAsync({
+        first: 100,
+        sortBy: ['title', true],
+        directory: uri,
+      });
 
       setTracks(results);
 
@@ -113,7 +95,7 @@ export default function TrackListScreen({ navigation }: Props) {
       <View style={styles.buttonContainer}>
         <Button
           title={`${loading ? 'loading...' : ''} get all tracks`}
-          onPress={getAllTracks}
+          onPress={handleGetAllTracks}
           disabled={loading}
         />
 

--- a/ios/MusicLibraryImpl.swift
+++ b/ios/MusicLibraryImpl.swift
@@ -11,6 +11,9 @@ import MediaPlayer
 enum MusicLibraryError: LocalizedError {
   case permissionDenied
   case trackNotFound(String)
+  case invalidCursor(String)
+  case cursorNotFound(String)
+  case invalidPageSize(Int)
 
   var code: String {
     switch self {
@@ -18,6 +21,12 @@ enum MusicLibraryError: LocalizedError {
       return "PERMISSION_DENIED"
     case .trackNotFound:
       return "TRACK_NOT_FOUND"
+    case .invalidCursor:
+      return "INVALID_CURSOR"
+    case .cursorNotFound:
+      return "CURSOR_NOT_FOUND"
+    case .invalidPageSize:
+      return "INVALID_PAGE_SIZE"
     }
   }
 
@@ -27,6 +36,12 @@ enum MusicLibraryError: LocalizedError {
       return "Audio permission is required. Please grant media library permission first."
     case .trackNotFound(let trackId):
       return "Track with id \(trackId) not found"
+    case .invalidCursor(let cursor):
+      return "Cursor must be a positive decimal ID: \(cursor)"
+    case .cursorNotFound(let cursor):
+      return "Cursor is not present in the current query result: \(cursor)"
+    case .invalidPageSize(let first):
+      return "Page size must be between 1 and 1000: \(first)"
     }
   }
 }
@@ -41,7 +56,7 @@ public class MusicLibraryImpl: NSObject {
     do {
       try ensureAuthorized()
       let getTracks = GetTracks(options: options)
-      let result = getTracks.execute()
+      let result = try getTracks.execute()
       let resultDict = result.toDictionary()
 
       NSLog("🎵 [MusicLibrary] getTracksAsync returning: %@", resultDict)
@@ -91,7 +106,7 @@ public class MusicLibraryImpl: NSObject {
     do {
       try ensureAuthorized()
       let options = TrackOptions(after: after, first: first, sortBy: sortBy, directory: directory)
-      let result = GetTracksByArtistQuery.getTracksByArtist(artistId: artistId, options: options)
+      let result = try GetTracksByArtistQuery.getTracksByArtist(artistId: artistId, options: options)
       resolve(result.toDictionary())
     } catch {
       rejectError(error, fallbackCode: "QUERY_ERROR", fallbackMessage: "Failed to query tracks by artist", reject: reject)
@@ -102,7 +117,7 @@ public class MusicLibraryImpl: NSObject {
     do {
       try ensureAuthorized()
       let options = AlbumOptions(after: after, first: first, sortBy: sortBy)
-      let result = GetAlbumsQuery.getAlbums(options: options)
+      let result = try GetAlbumsQuery.getAlbums(options: options)
       resolve(result.toDictionary())
     } catch {
       rejectError(error, fallbackCode: "QUERY_ERROR", fallbackMessage: "Failed to query albums", reject: reject)
@@ -123,7 +138,7 @@ public class MusicLibraryImpl: NSObject {
     do {
       try ensureAuthorized()
       let options = ArtistOptions(after: after, first: first, sortBy: sortBy)
-      let result = GetArtistsQuery.getArtists(options: options)
+      let result = try GetArtistsQuery.getArtists(options: options)
       resolve(result.toDictionary())
     } catch {
       rejectError(error, fallbackCode: "QUERY_ERROR", fallbackMessage: "Failed to query artists", reject: reject)

--- a/ios/MusicLibraryImpl.swift
+++ b/ios/MusicLibraryImpl.swift
@@ -73,7 +73,7 @@ public class MusicLibraryImpl: NSObject {
     Task { @MainActor in
       do {
         try ensureAuthorized()
-        guard let metadata = try await GetTrackMetadataQuery.getTrackMetadata(trackId: trackId) else {
+        guard let metadata = await GetTrackMetadataQuery.getTrackMetadata(trackId: trackId) else {
           throw MusicLibraryError.trackNotFound(trackId)
         }
         let resultDict = metadata.toDictionary()

--- a/ios/albums/GetAlbumsQuery.swift
+++ b/ios/albums/GetAlbumsQuery.swift
@@ -3,39 +3,28 @@ import MediaPlayer
 
 internal class GetAlbumsQuery {
 
-  static func getAlbums(options: AlbumOptions) -> PaginatedResult<Album> {
+  static func getAlbums(options: AlbumOptions) throws -> PaginatedResult<Album> {
     guard MPMediaLibrary.authorizationStatus() == .authorized else {
       return PaginatedResult<Album>(items: [], hasNextPage: false, totalCount: 0)
     }
 
     let query = MPMediaQuery.albums()
-    guard let collections = query.collections else {
-      return PaginatedResult<Album>(items: [], hasNextPage: false, totalCount: 0)
-    }
-
-    var albums = collections.compactMap { buildAlbum($0) }
+    var albums = (query.collections ?? []).compactMap { buildAlbum($0) }
 
     applySortBy(options.sortBy, to: &albums)
 
-    let totalCount = albums.count
-    var startIndex = 0
-    if let after = options.after {
-      if let idx = albums.firstIndex(where: { $0.id == after }) {
-        startIndex = idx + 1
-      }
-    }
-
-    let endIndex = min(startIndex + options.first, albums.count)
-    let page = startIndex < albums.count ? Array(albums[startIndex..<endIndex]) : []
-
-    let hasNextPage = endIndex < albums.count
-    let endCursor = page.last?.id
+    let page = try paginateById(
+      albums,
+      first: options.first,
+      after: options.after,
+      id: { $0.id }
+    )
 
     return PaginatedResult<Album>(
-      items: page,
-      hasNextPage: hasNextPage,
-      endCursor: endCursor,
-      totalCount: totalCount
+      items: page.items,
+      hasNextPage: page.hasNextPage,
+      endCursor: page.endCursor,
+      totalCount: albums.count
     )
   }
 
@@ -65,23 +54,38 @@ internal class GetAlbumsQuery {
   }
 
   private static func applySortBy(_ sortBy: [SortOption], to albums: inout [Album]) {
-    for sortOption in sortBy {
-      let ascending = sortOption.ascending
-      switch sortOption.key.lowercased() {
-      case "default", "title":
-        albums.sort { ascending ? $0.title < $1.title : $0.title > $1.title }
-      case "artist":
-        albums.sort { ascending ? $0.artist < $1.artist : $0.artist > $1.artist }
-      case "trackcount":
-        albums.sort { ascending ? $0.trackCount < $1.trackCount : $0.trackCount > $1.trackCount }
-      case "year":
-        albums.sort {
-          let y0 = $0.year ?? 0
-          let y1 = $1.year ?? 0
-          return ascending ? y0 < y1 : y0 > y1
+    let options = sortBy.isEmpty ? [SortOption(key: "default", ascending: true)] : sortBy
+    albums.sort { lhs, rhs in
+      for option in options {
+        if let result = compare(lhs, rhs, by: option) {
+          return result
         }
-      default: break
       }
+
+      return (UInt64(lhs.id) ?? 0) < (UInt64(rhs.id) ?? 0)
     }
+  }
+
+  private static func compare(_ lhs: Album, _ rhs: Album, by option: SortOption) -> Bool? {
+    switch option.key.lowercased() {
+    case "default", "title":
+      return compare(lhs.title, rhs.title, ascending: option.ascending)
+    case "artist":
+      return compare(lhs.artist, rhs.artist, ascending: option.ascending)
+    case "trackcount":
+      return compare(lhs.trackCount, rhs.trackCount, ascending: option.ascending)
+    case "year":
+      return compare(lhs.year ?? 0, rhs.year ?? 0, ascending: option.ascending)
+    default:
+      return nil
+    }
+  }
+
+  private static func compare<T: Comparable>(_ lhs: T, _ rhs: T, ascending: Bool) -> Bool? {
+    if lhs == rhs {
+      return nil
+    }
+
+    return ascending ? lhs < rhs : lhs > rhs
   }
 }

--- a/ios/artists/GetArtistsQuery.swift
+++ b/ios/artists/GetArtistsQuery.swift
@@ -3,39 +3,28 @@ import MediaPlayer
 
 internal class GetArtistsQuery {
 
-  static func getArtists(options: ArtistOptions) -> PaginatedResult<Artist> {
+  static func getArtists(options: ArtistOptions) throws -> PaginatedResult<Artist> {
     guard MPMediaLibrary.authorizationStatus() == .authorized else {
       return PaginatedResult<Artist>(items: [], hasNextPage: false, totalCount: 0)
     }
 
     let artistQuery = MPMediaQuery.artists()
-    guard let artistCollections = artistQuery.collections else {
-      return PaginatedResult<Artist>(items: [], hasNextPage: false, totalCount: 0)
-    }
-
-    var artists = artistCollections.compactMap { buildArtist($0) }
+    var artists = (artistQuery.collections ?? []).compactMap { buildArtist($0) }
 
     applySortBy(options.sortBy, to: &artists)
 
-    let totalCount = artists.count
-    var startIndex = 0
-    if let after = options.after {
-      if let idx = artists.firstIndex(where: { $0.id == after }) {
-        startIndex = idx + 1
-      }
-    }
-
-    let endIndex = min(startIndex + options.first, artists.count)
-    let page = startIndex < artists.count ? Array(artists[startIndex..<endIndex]) : []
-
-    let hasNextPage = endIndex < artists.count
-    let endCursor = page.last?.id
+    let page = try paginateById(
+      artists,
+      first: options.first,
+      after: options.after,
+      id: { $0.id }
+    )
 
     return PaginatedResult<Artist>(
-      items: page,
-      hasNextPage: hasNextPage,
-      endCursor: endCursor,
-      totalCount: totalCount
+      items: page.items,
+      hasNextPage: page.hasNextPage,
+      endCursor: page.endCursor,
+      totalCount: artists.count
     )
   }
 
@@ -67,17 +56,36 @@ internal class GetArtistsQuery {
   }
 
   private static func applySortBy(_ sortBy: [SortOption], to artists: inout [Artist]) {
-    for sortOption in sortBy {
-      let ascending = sortOption.ascending
-      switch sortOption.key.lowercased() {
-      case "default", "title":
-        artists.sort { ascending ? $0.title < $1.title : $0.title > $1.title }
-      case "trackcount":
-        artists.sort { ascending ? $0.trackCount < $1.trackCount : $0.trackCount > $1.trackCount }
-      case "albumcount":
-        artists.sort { ascending ? $0.albumCount < $1.albumCount : $0.albumCount > $1.albumCount }
-      default: break
+    let options = sortBy.isEmpty ? [SortOption(key: "default", ascending: true)] : sortBy
+    artists.sort { lhs, rhs in
+      for option in options {
+        if let result = compare(lhs, rhs, by: option) {
+          return result
+        }
       }
+
+      return (UInt64(lhs.id) ?? 0) < (UInt64(rhs.id) ?? 0)
     }
+  }
+
+  private static func compare(_ lhs: Artist, _ rhs: Artist, by option: SortOption) -> Bool? {
+    switch option.key.lowercased() {
+    case "default", "title":
+      return compare(lhs.title, rhs.title, ascending: option.ascending)
+    case "trackcount":
+      return compare(lhs.trackCount, rhs.trackCount, ascending: option.ascending)
+    case "albumcount":
+      return compare(lhs.albumCount, rhs.albumCount, ascending: option.ascending)
+    default:
+      return nil
+    }
+  }
+
+  private static func compare<T: Comparable>(_ lhs: T, _ rhs: T, ascending: Bool) -> Bool? {
+    if lhs == rhs {
+      return nil
+    }
+
+    return ascending ? lhs < rhs : lhs > rhs
   }
 }

--- a/ios/models/PaginatedResult.swift
+++ b/ios/models/PaginatedResult.swift
@@ -8,6 +8,47 @@ import Foundation
 
 // MARK: - Result Models
 
+internal struct CursorPage<T> {
+  let items: [T]
+  let hasNextPage: Bool
+  let endCursor: String?
+}
+
+internal func paginateById<T>(
+  _ items: [T],
+  first: Int,
+  after: String?,
+  id: (T) -> String
+) throws -> CursorPage<T> {
+  guard (1...1000).contains(first) else {
+    throw MusicLibraryError.invalidPageSize(first)
+  }
+
+  var startIndex = 0
+  if let after {
+    let validRange = after.range(
+      of: "^[1-9][0-9]*$",
+      options: .regularExpression
+    )
+    guard validRange != nil, UInt64(after) != nil else {
+      throw MusicLibraryError.invalidCursor(after)
+    }
+    guard let foundIndex = items.firstIndex(where: { id($0) == after }) else {
+      throw MusicLibraryError.cursorNotFound(after)
+    }
+    startIndex = foundIndex + 1
+  }
+
+  let endIndex = min(startIndex + first, items.count)
+  let page = startIndex < items.count ? Array(items[startIndex..<endIndex]) : []
+
+  return CursorPage(
+    items: page,
+    hasNextPage: endIndex < items.count,
+    endCursor: page.last.map(id)
+  )
+}
+
 public class PaginatedResult<T: NSObject>: NSObject {
   public let items: [T]
   public let hasNextPage: Bool
@@ -83,4 +124,3 @@ public class PaginatedResultArtist: NSObject {
     return inner.toDictionary()
   }
 }
-

--- a/ios/models/PaginatedResult.swift
+++ b/ios/models/PaginatedResult.swift
@@ -75,12 +75,19 @@ public class PaginatedResult<T: NSObject>: NSObject {
       return nil
     }
     
-    return [
+    var dictionary: [String: Any] = [
       "items": itemDictionaries,
-      "hasNextPage": hasNextPage,
-      "endCursor": endCursor ?? NSNull(),
-      "totalCount": totalCount ?? NSNull()
+      "hasNextPage": hasNextPage
     ]
+
+    if let endCursor {
+      dictionary["endCursor"] = endCursor
+    }
+    if let totalCount {
+      dictionary["totalCount"] = totalCount
+    }
+
+    return dictionary
   }
 }
 

--- a/ios/tracks/GetTrackMetadataQuery.swift
+++ b/ios/tracks/GetTrackMetadataQuery.swift
@@ -2,11 +2,11 @@ import Foundation
 
 @MainActor
 internal class GetTrackMetadataQuery {
-  static func getTrackMetadata(trackId: String) async throws -> TrackMetadata? {
+  static func getTrackMetadata(trackId: String) async -> TrackMetadata? {
     guard let item = TrackLibraryItemLookup.findTrack(trackId: trackId) else {
       return nil
     }
 
-    return try await TrackMetadataExtractor.extract(trackId: trackId, from: item)
+    return await TrackMetadataExtractor.extract(trackId: trackId, from: item)
   }
 }

--- a/ios/tracks/GetTracks.swift
+++ b/ios/tracks/GetTracks.swift
@@ -7,11 +7,11 @@ internal class GetTracks {
     self.options = options
   }
 
-  func execute() -> PaginatedResult<Track> {
+  func execute() throws -> PaginatedResult<Track> {
     if let directory = options.directory, !directory.isEmpty {
       NSLog("🎵 [MusicLibrary] Directory filtering ('%@') is not supported on iOS, ignoring parameter", directory)
     }
 
-    return TrackQuery.getPaginatedTracks(options: options)
+    return try TrackQuery.getPaginatedTracks(options: options)
   }
 }

--- a/ios/tracks/GetTracksByArtistQuery.swift
+++ b/ios/tracks/GetTracksByArtistQuery.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 internal class GetTracksByArtistQuery {
-  static func getTracksByArtist(artistId: String, options: TrackOptions) -> PaginatedResult<Track> {
-    return TrackQuery.getPaginatedTracks(filter: .artist(artistId), options: options)
+  static func getTracksByArtist(artistId: String, options: TrackOptions) throws -> PaginatedResult<Track> {
+    return try TrackQuery.getPaginatedTracks(filter: .artist(artistId), options: options)
   }
 }

--- a/ios/tracks/TrackMetadataExtractor.swift
+++ b/ios/tracks/TrackMetadataExtractor.swift
@@ -4,7 +4,7 @@ import MediaPlayer
 
 @MainActor
 internal enum TrackMetadataExtractor {
-  static func extract(trackId: String, from item: MPMediaItem) async throws -> TrackMetadata {
+  static func extract(trackId: String, from item: MPMediaItem) async -> TrackMetadata {
     let duration = item.playbackDuration
     var title = nonEmpty(item.title)
     var artist = nonEmpty(item.artist)
@@ -26,38 +26,38 @@ internal enum TrackMetadataExtractor {
 
     if let assetURL = item.assetURL {
       let asset = AVURLAsset(url: assetURL)
-      let audioInfo = try await extractAudioInfo(from: asset, duration: duration)
+      if let audioInfo = try? await extractAudioInfo(from: asset, duration: duration) {
+        bitrate = audioInfo.bitrate
+        sampleRate = audioInfo.sampleRate
+        channels = audioInfo.channels
+        format = audioInfo.format
+      }
 
-      bitrate = audioInfo.bitrate
-      sampleRate = audioInfo.sampleRate
-      channels = audioInfo.channels
-      format = audioInfo.format
-
-      let metadataItems = try await asset.load(.metadata)
+      let metadataItems = (try? await asset.load(.metadata)) ?? []
 
       if title == nil {
-        title = try await firstMetadataString(in: metadataItems, identifiers: [
+        title = try? await firstMetadataString(in: metadataItems, identifiers: [
           .commonIdentifierTitle,
           .iTunesMetadataSongName,
           .id3MetadataTitleDescription
         ])
       }
       if artist == nil {
-        artist = try await firstMetadataString(in: metadataItems, identifiers: [
+        artist = try? await firstMetadataString(in: metadataItems, identifiers: [
           .commonIdentifierArtist,
           .iTunesMetadataArtist,
           .id3MetadataLeadPerformer
         ])
       }
       if album == nil {
-        album = try await firstMetadataString(in: metadataItems, identifiers: [
+        album = try? await firstMetadataString(in: metadataItems, identifiers: [
           .commonIdentifierAlbumName,
           .iTunesMetadataAlbum,
           .id3MetadataAlbumTitle
         ])
       }
       if year == nil {
-        year = try await firstMetadataInt(in: metadataItems, identifiers: [
+        year = try? await firstMetadataInt(in: metadataItems, identifiers: [
           .commonIdentifierCreationDate,
           .iTunesMetadataReleaseDate,
           .id3MetadataYear,
@@ -66,52 +66,52 @@ internal enum TrackMetadataExtractor {
         ])
       }
       if genre == nil {
-        genre = try await firstMetadataString(in: metadataItems, identifiers: [
+        genre = try? await firstMetadataString(in: metadataItems, identifiers: [
           .iTunesMetadataUserGenre,
           .iTunesMetadataPredefinedGenre,
           .id3MetadataContentType
         ])
       }
       if trackNumber == nil {
-        trackNumber = try await firstMetadataInt(in: metadataItems, identifiers: [
+        trackNumber = try? await firstMetadataInt(in: metadataItems, identifiers: [
           .iTunesMetadataTrackNumber,
           .id3MetadataTrackNumber
         ])
       }
       if discNumber == nil {
-        discNumber = try await firstMetadataInt(in: metadataItems, identifiers: [
+        discNumber = try? await firstMetadataInt(in: metadataItems, identifiers: [
           .iTunesMetadataDiscNumber,
           .id3MetadataPartOfASet
         ])
       }
       if composer == nil {
-        composer = try await firstMetadataString(in: metadataItems, identifiers: [
+        composer = try? await firstMetadataString(in: metadataItems, identifiers: [
           .iTunesMetadataComposer,
           .id3MetadataComposer,
           .quickTimeUserDataComposer,
           .quickTimeMetadataComposer
         ])
       }
-      lyricist = try await firstMetadataString(in: metadataItems, identifiers: [
+      lyricist = try? await firstMetadataString(in: metadataItems, identifiers: [
         .id3MetadataLyricist,
         .id3MetadataOriginalLyricist,
         .quickTimeUserDataWriter
       ])
       if lyrics == nil {
-        lyrics = try await firstMetadataString(in: metadataItems, identifiers: [
+        lyrics = try? await firstMetadataString(in: metadataItems, identifiers: [
           .iTunesMetadataLyrics,
           .id3MetadataUnsynchronizedLyric,
           .id3MetadataSynchronizedLyric
         ])
       }
       if albumArtist == nil {
-        albumArtist = try await firstMetadataString(in: metadataItems, identifiers: [
+        albumArtist = try? await firstMetadataString(in: metadataItems, identifiers: [
           .iTunesMetadataAlbumArtist,
           .id3MetadataBand
         ])
       }
       if comment == nil {
-        comment = try await firstMetadataString(in: metadataItems, identifiers: [
+        comment = try? await firstMetadataString(in: metadataItems, identifiers: [
           .iTunesMetadataUserComment,
           .id3MetadataComments,
           .quickTimeUserDataComment,

--- a/ios/tracks/TrackQuery.swift
+++ b/ios/tracks/TrackQuery.swift
@@ -18,14 +18,17 @@ internal enum TrackSortPolicy {
 }
 
 internal class TrackQuery {
-  static func getPaginatedTracks(filter: TrackQueryFilter = .all, options: TrackOptions) -> PaginatedResult<Track> {
-    guard var items = queryItems(filter: filter) else {
-      return PaginatedResult<Track>(items: [], hasNextPage: false, totalCount: 0)
-    }
+  static func getPaginatedTracks(filter: TrackQueryFilter = .all, options: TrackOptions) throws -> PaginatedResult<Track> {
+    var items = queryItems(filter: filter) ?? []
 
     applySort(.options(options.sortBy), to: &items)
 
-    let page = paginate(items, first: options.first, after: options.after)
+    let page = try paginateById(
+      items,
+      first: options.first,
+      after: options.after,
+      id: { "\($0.persistentID)" }
+    )
     let tracks = page.items.compactMap {
       buildTrack(from: $0, resourcePolicy: .allowLibraryFallback)
     }
@@ -94,7 +97,13 @@ internal class TrackQuery {
           return lhs.albumTrackNumber < rhs.albumTrackNumber
         }
 
-        return (lhs.title ?? "") < (rhs.title ?? "")
+        let lhsTitle = lhs.title ?? ""
+        let rhsTitle = rhs.title ?? ""
+        if lhsTitle != rhsTitle {
+          return lhsTitle < rhsTitle
+        }
+
+        return lhs.persistentID < rhs.persistentID
       }
     case .options(let sortBy):
       let options = sortBy.isEmpty ? [SortOption(key: "default", ascending: true)] : sortBy
@@ -126,8 +135,10 @@ internal class TrackQuery {
       return compare(lhs.albumTitle ?? "", rhs.albumTitle ?? "", ascending: ascending)
     case "duration":
       return compare(lhs.playbackDuration, rhs.playbackDuration, ascending: ascending)
-    case "createdat", "creationtime", "modifiedat", "modificationtime":
+    case "createdat", "creationtime":
       return compare(lhs.dateAdded, rhs.dateAdded, ascending: ascending)
+    case "modifiedat", "modificationtime":
+      return nil
     case "filesize":
       return compare(fileSize(for: lhs), fileSize(for: rhs), ascending: ascending)
     default:
@@ -141,25 +152,6 @@ internal class TrackQuery {
     }
 
     return ascending ? lhs < rhs : lhs > rhs
-  }
-
-  private static func paginate(_ items: [MPMediaItem], first: Int, after: String?) -> (items: [MPMediaItem], hasNextPage: Bool, endCursor: String?) {
-    var startIndex = 0
-
-    if let after = after, let afterId = UInt64(after),
-       let foundIndex = items.firstIndex(where: { $0.persistentID == afterId }) {
-      startIndex = foundIndex + 1
-    }
-
-    let endIndex = min(startIndex + first, items.count)
-    let page = startIndex < items.count ? Array(items[startIndex..<endIndex]) : []
-    let endCursor = page.last.map { "\($0.persistentID)" } ?? after
-
-    return (
-      items: page,
-      hasNextPage: endIndex < items.count,
-      endCursor: endCursor
-    )
   }
 
   private static func buildTrack(from item: MPMediaItem, resourcePolicy: TrackResourcePolicy) -> Track? {
@@ -176,7 +168,7 @@ internal class TrackQuery {
       duration: item.playbackDuration,
       url: urlString,
       createdAt: item.dateAdded.timeIntervalSince1970,
-      modifiedAt: item.dateAdded.timeIntervalSince1970,
+      modifiedAt: nil,
       fileSize: fileSize(for: item)
     )
   }

--- a/ios/utils/DataConverter.swift
+++ b/ios/utils/DataConverter.swift
@@ -41,14 +41,4 @@ internal class DataConverter {
     return result.toDictionary()
   }
   
-  // MARK: - Error Handling
-  
-  static func createErrorDictionary(code: String, message: String) -> [String: Any] {
-    return [
-      "error": [
-        "code": code,
-        "message": message
-      ]
-    ]
-  }
 }

--- a/src/NativeMusicLibrary.ts
+++ b/src/NativeMusicLibrary.ts
@@ -186,8 +186,11 @@ export interface Track {
   /** Duration in seconds */
   duration: number;
 
-  /** File URI or path */
+  /** Playable resource URI. May use file, content, or platform-library schemes. */
   url: string;
+
+  /** Canonical Android MediaStore content URI (Android only) */
+  contentUri?: string | null;
 
   /** Date added to the library as a Unix timestamp in seconds (optional) */
   createdAt?: number | null;

--- a/src/NativeMusicLibrary.ts
+++ b/src/NativeMusicLibrary.ts
@@ -30,6 +30,19 @@ export interface InternalSortByValue {
   ascending: boolean;
 }
 
+export type MusicLibraryErrorCode =
+  | 'PERMISSION_DENIED'
+  | 'TRACK_NOT_FOUND'
+  | 'QUERY_ERROR'
+  | 'INVALID_CURSOR'
+  | 'CURSOR_NOT_FOUND'
+  | 'INVALID_PAGE_SIZE'
+  | 'UNSUPPORTED_DIRECTORY_URI';
+
+export interface MusicLibraryError extends Error {
+  code: MusicLibraryErrorCode;
+}
+
 export const TrackSortByObject = {
   default: 'default',
   title: 'title',
@@ -175,13 +188,13 @@ export interface Track {
   title: string;
 
   /** Artist name */
-  artist?: string | null;
+  artist: string | null;
 
-  /** Track artwork (file URI, optional) */
-  artwork?: string | null;
+  /** Track artwork reference, or null when unavailable */
+  artwork: string | null;
 
   /** Album name */
-  album?: string | null;
+  album: string | null;
 
   /** Duration in seconds */
   duration: number;
@@ -192,11 +205,11 @@ export interface Track {
   /** Canonical Android MediaStore content URI (Android only) */
   contentUri?: string | null;
 
-  /** Date added to the library as a Unix timestamp in seconds (optional) */
-  createdAt?: number | null;
+  /** Date added to the library as a Unix timestamp in seconds, or null */
+  createdAt: number | null;
 
   /** Resource modification time in Unix seconds; unavailable and null on iOS */
-  modifiedAt?: number | null;
+  modifiedAt: number | null;
 
   /** File size in bytes */
   fileSize: number;
@@ -207,25 +220,25 @@ export interface TrackMetadata {
   id: string;
 
   /** Audio header */
-  duration?: number | null; // in seconds
-  bitrate?: number | null; // in kbps
-  sampleRate?: number | null; // in Hz
-  channels?: string | null;
-  format?: string | null;
+  duration: number | null; // in seconds
+  bitrate: number | null; // in kbps
+  sampleRate: number | null; // in Hz
+  channels: string | null;
+  format: string | null;
 
   /** Tag info */
-  title?: string | null;
-  artist?: string | null;
-  album?: string | null;
-  year?: number | null;
-  genre?: string | null;
-  track?: number | null;
-  disc?: number | null;
-  composer?: string | null;
-  lyricist?: string | null;
-  lyrics?: string | null;
-  albumArtist?: string | null;
-  comment?: string | null;
+  title: string | null;
+  artist: string | null;
+  album: string | null;
+  year: number | null;
+  genre: string | null;
+  track: number | null;
+  disc: number | null;
+  composer: string | null;
+  lyricist: string | null;
+  lyrics: string | null;
+  albumArtist: string | null;
+  comment: string | null;
 }
 
 export interface Album {
@@ -241,10 +254,9 @@ export interface Album {
   artist: string;
 
   /**
-   * Album artwork (base64 encoded image or URL, optional)
-   * @default undefined
+   * Album artwork reference, or null when unavailable
    */
-  artwork?: string | null;
+  artwork: string | null;
 
   /**
    * Number of tracks in album
@@ -253,10 +265,9 @@ export interface Album {
   trackCount: number;
 
   /**
-   * Release year (optional)
-   * @default undefined
+   * Release year, or null when unavailable
    */
-  year?: number | null;
+  year: number | null;
 }
 
 export interface Artist {

--- a/src/NativeMusicLibrary.ts
+++ b/src/NativeMusicLibrary.ts
@@ -69,6 +69,8 @@ export interface BaseOptions {
   /**
    * Maximum number of items to return
    * @default 20
+   * @minimum 1
+   * @maximum 1000
    */
   first?: number;
 }
@@ -80,7 +82,7 @@ export interface TrackOptions extends BaseOptions {
   /**
    * Sorting configuration for tracks
    * @example
-   * 'title' // Sort by title descending (default)
+   * 'title' // Sort by title descending
    * ['title', true] // Sort by title ascending
    */
   sortBy?: SortByValue<TrackSortByKey> | SortByValue<TrackSortByKey>[];
@@ -99,7 +101,7 @@ export interface AlbumOptions extends BaseOptions {
   /**
    * Sorting configuration for albums
    * @example
-   * 'title' // Sort by title descending (default)
+   * 'title' // Sort by title descending
    * ['trackCount', true] // Sort by track count ascending
    */
   sortBy?: SortByValue<AlbumSortByKey> | SortByValue<AlbumSortByKey>[];
@@ -112,7 +114,7 @@ export interface ArtistOptions extends BaseOptions {
   /**
    * Sorting configuration for artists
    * @example
-   * 'title' // Sort by name descending (default)
+   * 'title' // Sort by name descending
    * ['trackCount', true] // Sort by track count ascending
    */
   sortBy?: SortByValue<ArtistSortByKey> | SortByValue<ArtistSortByKey>[];
@@ -187,10 +189,10 @@ export interface Track {
   /** File URI or path */
   url: string;
 
-  /** Date added to library (Unix timestamp, optional) */
+  /** Date added to the library as a Unix timestamp in seconds (optional) */
   createdAt?: number | null;
 
-  /** Date modified (Unix timestamp, optional) */
+  /** Resource modification time in Unix seconds; unavailable and null on iOS */
   modifiedAt?: number | null;
 
   /** File size in bytes */

--- a/src/NativeMusicLibrary.web.ts
+++ b/src/NativeMusicLibrary.web.ts
@@ -50,7 +50,6 @@ const MusicLibrary: Spec = {
     return {
       items: [],
       hasNextPage: false,
-      endCursor: undefined,
       totalCount: 0,
     };
   },
@@ -59,28 +58,27 @@ const MusicLibrary: Spec = {
     showWebWarning();
     return {
       id: trackId,
-      duration: 0,
-      bitrate: 0,
-      sampleRate: 0,
-      channels: '',
-      format: '',
-      title: '',
-      artist: '',
-      album: '',
-      year: 0,
-      genre: '',
-      track: 0,
-      disc: 0,
-      composer: '',
-      lyricist: '',
-      lyrics: '',
-      albumArtist: '',
-      comment: '',
+      duration: null,
+      bitrate: null,
+      sampleRate: null,
+      channels: null,
+      format: null,
+      title: null,
+      artist: null,
+      album: null,
+      year: null,
+      genre: null,
+      track: null,
+      disc: null,
+      composer: null,
+      lyricist: null,
+      lyrics: null,
+      albumArtist: null,
+      comment: null,
     };
   },
 
-  async getTracksByAlbumAsync(albumId: string): Promise<Track[]> {
-    console.log('getTracksByAlbumAsync', albumId);
+  async getTracksByAlbumAsync(_albumId: string): Promise<Track[]> {
     showWebWarning();
     return [];
   },
@@ -90,7 +88,6 @@ const MusicLibrary: Spec = {
     return {
       items: [],
       hasNextPage: false,
-      endCursor: undefined,
       totalCount: 0,
     };
   },
@@ -100,13 +97,11 @@ const MusicLibrary: Spec = {
     return {
       items: [],
       hasNextPage: false,
-      endCursor: undefined,
       totalCount: 0,
     };
   },
 
-  async getAlbumsByArtistAsync(artistId: string): Promise<Album[]> {
-    console.log('getAlbumsByArtistAsync', artistId);
+  async getAlbumsByArtistAsync(_artistId: string): Promise<Album[]> {
     showWebWarning();
     return [];
   },
@@ -116,7 +111,6 @@ const MusicLibrary: Spec = {
     return {
       items: [],
       hasNextPage: false,
-      endCursor: undefined,
       totalCount: 0,
     };
   },

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,7 +1,12 @@
 import type { TrackSortByKey } from '../NativeMusicLibrary';
 import MusicLibrary from '../NativeMusicLibrary';
-import { getAllTracksAsync } from '../index';
-import { getTrackOptions, normalizeSortBy } from '../utils';
+import { getAlbumsAsync, getAllTracksAsync } from '../index';
+import {
+  getAlbumOptions,
+  getArtistOptions,
+  getTrackOptions,
+  normalizeSortBy,
+} from '../utils';
 
 // Mock the native module
 jest.mock('../NativeMusicLibrary', () => ({
@@ -106,6 +111,43 @@ describe('getTrackOptions', () => {
       { key: 'duration', ascending: false },
     ]);
   });
+
+  it.each(['', '0', '-1', '1.5', 'abc', '1abc', '18446744073709551616'])(
+    'rejects malformed cursor %p',
+    (after) => {
+      expect(() => getTrackOptions({ after })).toThrow(
+        expect.objectContaining({ code: 'INVALID_CURSOR' })
+      );
+    }
+  );
+
+  it('accepts a positive decimal entity ID cursor', () => {
+    expect(getTrackOptions({ after: '18446744073709551615' }).after).toBe(
+      '18446744073709551615'
+    );
+  });
+
+  it.each([0, -1, 1.5, 1001, Number.POSITIVE_INFINITY])(
+    'rejects invalid page size %p',
+    (first) => {
+      expect(() => getTrackOptions({ first })).toThrow(
+        expect.objectContaining({ code: 'INVALID_PAGE_SIZE' })
+      );
+    }
+  );
+
+  it.each([1, 1000])('accepts page-size boundary %p', (first) => {
+    expect(getTrackOptions({ first }).first).toBe(first);
+  });
+
+  it('applies the same cursor and page-size validation to every entity', () => {
+    expect(() => getAlbumOptions({ after: 'bad' })).toThrow(
+      expect.objectContaining({ code: 'INVALID_CURSOR' })
+    );
+    expect(() => getArtistOptions({ first: 1001 })).toThrow(
+      expect.objectContaining({ code: 'INVALID_PAGE_SIZE' })
+    );
+  });
 });
 
 describe('getAllTracksAsync', () => {
@@ -159,6 +201,19 @@ describe('getAllTracksAsync', () => {
     await expect(getAllTracksAsync()).rejects.toThrow(
       'Pagination did not provide an end cursor.'
     );
+  });
+});
+
+describe('public pagination validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects malformed cursors with a stable error code before native query', async () => {
+    await expect(getAlbumsAsync({ after: 'bad' })).rejects.toMatchObject({
+      code: 'INVALID_CURSOR',
+    });
+    expect(mockMusicLibrary.getAlbumsAsync).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,5 +1,6 @@
 import type { TrackSortByKey } from '../NativeMusicLibrary';
 import MusicLibrary from '../NativeMusicLibrary';
+import WebMusicLibrary from '../NativeMusicLibrary.web';
 import {
   getAlbumsAsync,
   getAllAlbumsAsync,
@@ -286,6 +287,53 @@ describe('public pagination validation', () => {
       code: 'INVALID_CURSOR',
     });
     expect(mockMusicLibrary.getAlbumsAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('web result contract', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('omits an end cursor from an empty terminal page', async () => {
+    const result = await WebMusicLibrary.getTracksAsync({
+      first: 20,
+      sortBy: [],
+    });
+
+    expect(result).toEqual({
+      items: [],
+      hasNextPage: false,
+      totalCount: 0,
+    });
+    expect(result).not.toHaveProperty('endCursor');
+  });
+
+  it('returns every unavailable metadata field as null', async () => {
+    await expect(WebMusicLibrary.getTrackMetadataAsync('42')).resolves.toEqual({
+      id: '42',
+      duration: null,
+      bitrate: null,
+      sampleRate: null,
+      channels: null,
+      format: null,
+      title: null,
+      artist: null,
+      album: null,
+      year: null,
+      genre: null,
+      track: null,
+      disc: null,
+      composer: null,
+      lyricist: null,
+      lyrics: null,
+      albumArtist: null,
+      comment: null,
+    });
   });
 });
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,6 +1,11 @@
 import type { TrackSortByKey } from '../NativeMusicLibrary';
 import MusicLibrary from '../NativeMusicLibrary';
-import { getAlbumsAsync, getAllTracksAsync } from '../index';
+import {
+  getAlbumsAsync,
+  getAllAlbumsAsync,
+  getAllArtistsAsync,
+  getAllTracksAsync,
+} from '../index';
 import {
   getAlbumOptions,
   getArtistOptions,
@@ -202,6 +207,73 @@ describe('getAllTracksAsync', () => {
       'Pagination did not provide an end cursor.'
     );
   });
+
+  it('returns an empty list for an empty library', async () => {
+    mockMusicLibrary.getTracksAsync.mockResolvedValueOnce({
+      items: [],
+      hasNextPage: false,
+      totalCount: 0,
+    });
+
+    await expect(getAllTracksAsync()).resolves.toEqual([]);
+  });
+
+  it('fails when a native cursor repeats instead of advancing', async () => {
+    mockMusicLibrary.getTracksAsync
+      .mockResolvedValueOnce({
+        items: [createTrack('1')],
+        hasNextPage: true,
+        endCursor: '1',
+      })
+      .mockResolvedValueOnce({
+        items: [createTrack('1')],
+        hasNextPage: true,
+        endCursor: '1',
+      });
+
+    await expect(getAllTracksAsync()).rejects.toThrow(
+      'Pagination cursor did not advance.'
+    );
+    expect(mockMusicLibrary.getTracksAsync).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('complete entity helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('collects every album through the shared pagination loop', async () => {
+    const album = createAlbum('1');
+    mockMusicLibrary.getAlbumsAsync.mockResolvedValueOnce({
+      items: [album],
+      hasNextPage: false,
+      totalCount: 1,
+    });
+
+    await expect(getAllAlbumsAsync({ first: 50 })).resolves.toEqual([album]);
+    expect(mockMusicLibrary.getAlbumsAsync).toHaveBeenCalledWith({
+      after: undefined,
+      first: 50,
+      sortBy: [{ key: 'default', ascending: true }],
+    });
+  });
+
+  it('collects every artist through the shared pagination loop', async () => {
+    const artist = createArtist('1');
+    mockMusicLibrary.getArtistsAsync.mockResolvedValueOnce({
+      items: [artist],
+      hasNextPage: false,
+      totalCount: 1,
+    });
+
+    await expect(getAllArtistsAsync()).resolves.toEqual([artist]);
+    expect(mockMusicLibrary.getArtistsAsync).toHaveBeenCalledWith({
+      after: undefined,
+      first: 20,
+      sortBy: [{ key: 'default', ascending: true }],
+    });
+  });
 });
 
 describe('public pagination validation', () => {
@@ -229,5 +301,25 @@ function createTrack(id: string) {
     createdAt: null,
     modifiedAt: null,
     fileSize: 1,
+  };
+}
+
+function createAlbum(id: string) {
+  return {
+    id,
+    title: `Album ${id}`,
+    artist: 'Artist',
+    artwork: null,
+    trackCount: 1,
+    year: null,
+  };
+}
+
+function createArtist(id: string) {
+  return {
+    id,
+    title: `Artist ${id}`,
+    albumCount: 1,
+    trackCount: 1,
   };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,7 +62,7 @@ export function getTracksByAlbumAsync(albumId: string): Promise<Track[]> {
  * @param trackOptions - The options for the query (pagination, etc.).
  * @returns A promise that resolves to a paginated result of tracks by the artist.
  */
-export function getTracksByArtistAsync(
+export async function getTracksByArtistAsync(
   artistId: string,
   trackOptions: TrackOptions = {}
 ): Promise<TrackResult> {
@@ -93,7 +93,7 @@ export async function getAllTracksByArtistAsync(
  * @param albumOptions - The options for the query.
  * @returns A promise that resolves to an array of album info.
  */
-export function getAlbumsAsync(
+export async function getAlbumsAsync(
   albumOptions: AlbumOptions = {}
 ): Promise<AlbumResult> {
   return MusicLibrary.getAlbumsAsync(getAlbumOptions(albumOptions));
@@ -124,7 +124,7 @@ export function getAlbumsByArtistAsync(artistId: string): Promise<Album[]> {
  * @param artistOptions - The options for the query.
  * @returns A promise that resolves to an array of artist info.
  */
-export function getArtistsAsync(
+export async function getArtistsAsync(
   artistOptions: ArtistOptions = {}
 ): Promise<ArtistResult> {
   return MusicLibrary.getArtistsAsync(getArtistOptions(artistOptions));

--- a/src/index.web.tsx
+++ b/src/index.web.tsx
@@ -7,8 +7,10 @@ import type {
   AlbumResult,
   ArtistResult,
   TrackMetadata,
+  PaginatedResult,
   Track,
   Album,
+  Artist,
 } from './NativeMusicLibrary';
 import { getTrackOptions, getAlbumOptions, getArtistOptions } from './utils';
 
@@ -23,6 +25,12 @@ export async function getTracksAsync(
   trackOptions: TrackOptions = {}
 ): Promise<TrackResult> {
   return MusicLibrary.getTracksAsync(getTrackOptions(trackOptions));
+}
+
+export async function getAllTracksAsync(
+  trackOptions: TrackOptions = {}
+): Promise<Track[]> {
+  return collectPaginatedItems(getTracksAsync, trackOptions);
 }
 
 /**
@@ -49,7 +57,7 @@ export function getTracksByAlbumAsync(albumId: string): Promise<Track[]> {
  * @param trackOptions - The options for the query (pagination, etc.).
  * @returns A promise that resolves to a paginated result of tracks by the artist.
  */
-export function getTracksByArtistAsync(
+export async function getTracksByArtistAsync(
   artistId: string,
   trackOptions: TrackOptions = {}
 ): Promise<TrackResult> {
@@ -59,15 +67,31 @@ export function getTracksByArtistAsync(
   );
 }
 
+export async function getAllTracksByArtistAsync(
+  artistId: string,
+  trackOptions: TrackOptions = {}
+): Promise<Track[]> {
+  return collectPaginatedItems(
+    (options) => getTracksByArtistAsync(artistId, options),
+    trackOptions
+  );
+}
+
 /**
  * Get all albums from the music library.
  * @param albumOptions - The options for the query.
  * @returns A promise that resolves to an array of album info.
  */
-export function getAlbumsAsync(
+export async function getAlbumsAsync(
   albumOptions: AlbumOptions = {}
 ): Promise<AlbumResult> {
   return MusicLibrary.getAlbumsAsync(getAlbumOptions(albumOptions));
+}
+
+export async function getAllAlbumsAsync(
+  albumOptions: AlbumOptions = {}
+): Promise<Album[]> {
+  return collectPaginatedItems(getAlbumsAsync, albumOptions);
 }
 
 /**
@@ -84,10 +108,49 @@ export function getAlbumsByArtistAsync(artistId: string): Promise<Album[]> {
  * @param artistOptions - The options for the query.
  * @returns A promise that resolves to an array of artist info.
  */
-export function getArtistsAsync(
+export async function getArtistsAsync(
   artistOptions: ArtistOptions = {}
 ): Promise<ArtistResult> {
   return MusicLibrary.getArtistsAsync(getArtistOptions(artistOptions));
+}
+
+export async function getAllArtistsAsync(
+  artistOptions: ArtistOptions = {}
+): Promise<Artist[]> {
+  return collectPaginatedItems(getArtistsAsync, artistOptions);
+}
+
+async function collectPaginatedItems<T, TOptions extends { after?: string }>(
+  loadPage: (options: TOptions) => Promise<PaginatedResult<T>>,
+  options: TOptions
+): Promise<T[]> {
+  const items: T[] = [];
+  const seenCursors = new Set<string>();
+  let after = options.after;
+
+  while (true) {
+    const page = await loadPage({
+      ...options,
+      after,
+    });
+
+    items.push(...page.items);
+
+    if (!page.hasNextPage) {
+      return items;
+    }
+
+    if (!page.endCursor) {
+      throw new Error('Pagination did not provide an end cursor.');
+    }
+
+    if (page.endCursor === after || seenCursors.has(page.endCursor)) {
+      throw new Error('Pagination cursor did not advance.');
+    }
+
+    seenCursors.add(page.endCursor);
+    after = page.endCursor;
+  }
 }
 
 export default MusicLibrary;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import { Platform } from 'react-native';
 import {
   TrackSortByObject,
   AlbumSortByObject,
@@ -14,6 +13,7 @@ import {
 } from './NativeMusicLibrary';
 
 type SortByType = 'track' | 'album' | 'artist';
+const MAX_CURSOR_ID = '18446744073709551615';
 
 export function arrayize<T>(item: T | T[]): T[] {
   if (Array.isArray(item)) {
@@ -166,14 +166,33 @@ function validateOptions(options: any): void {
   if (options.directory != null && typeof options.directory !== 'string') {
     throw new Error('Option "directory" must be a string!');
   }
+  if (options.after != null && !isValidCursor(options.after)) {
+    throw createOptionError(
+      'INVALID_CURSOR',
+      'Option "after" must be a positive decimal ID!'
+    );
+  }
   if (
-    options.after != null &&
-    Platform.OS === 'android' &&
-    isNaN(parseInt(getId(options.after) as string, 10))
+    options.first != null &&
+    (!Number.isInteger(options.first) ||
+      options.first < 1 ||
+      options.first > 1000)
   ) {
-    throw new Error('Option "after" must be a valid ID!');
+    throw createOptionError(
+      'INVALID_PAGE_SIZE',
+      'Option "first" must be an integer between 1 and 1000!'
+    );
   }
-  if (options.first != null && options.first < 0) {
-    throw new Error('Option "first" must be a positive integer!');
-  }
+}
+
+function isValidCursor(cursor: string): boolean {
+  return (
+    /^[1-9]\d*$/.test(cursor) &&
+    (cursor.length < MAX_CURSOR_ID.length ||
+      (cursor.length === MAX_CURSOR_ID.length && cursor <= MAX_CURSOR_ID))
+  );
+}
+
+function createOptionError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
 }


### PR DESCRIPTION
## Summary

- enforce stable ID-based cursor, sorting, page-boundary, timestamp, nullable-result, and error contracts across Android and iOS
- prevent non-advancing Android Album and Artist query loops and add complete-library JS helpers used by the example app
- adopt Android content URI-first Track access while retaining compatible `url` behavior and safe directory filtering
- align the web fallback, public types, English/Chinese documentation, and regression coverage

## Verification

- `yarn typecheck`
- `yarn test --runInBand` (33 tests)
- `yarn lint`
- Android unit tests, Kotlin compilation, and lint
- iOS simulator build for arm64 and x86_64
- English and Chinese Docusaurus production builds
- physical-device behavior verified by the maintainer

Closes #13
Closes #14
Closes #17
Closes #20
Closes #21